### PR TITLE
Some code cleanup

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,11 @@ impl From<ByteKey> for NibbleKey {
 
 impl From<Vec<u8>> for NibbleKey {
     fn from(nibbles: Vec<u8>) -> Self {
+        for nibble in nibbles.iter() {
+            if *nibble >= 16 {
+                panic!("Nibble value is higher than 15");
+            }
+        }
         NibbleKey(nibbles)
     }
 }
@@ -34,15 +39,6 @@ impl From<&[u8]> for NibbleKey {
 }
 
 impl NibbleKey {
-    pub fn new(nibbles: Vec<u8>) -> Self {
-        for nibble in nibbles.iter() {
-            if *nibble >= 16 {
-                panic!("Nibble value is higher than 15");
-            }
-        }
-        NibbleKey(nibbles.clone())
-    }
-
     // Find the length of the common prefix of two keys
     pub fn factor_length(&self, other: &Self) -> usize {
         let (ref longuest, ref shortest) = if self.0.len() > other.0.len() {


### PR DESCRIPTION
A series of changes to clean the code up:

  * Remove the use for `NibbleKey::new` since `From<Vec<u8>>` has been implemented;
  * Rely on `hex::decode` instead of having a custom function
  * Change the implementation of `display` to write the regular data, instead of writing its "debug" version
  * Remove some comments

I realize that the reason @sina created a custom hex conversion function might have been done with the hope of reducing the size of the final binary. Is that so?