### PR TITLE
Multiproof with tree trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,5 @@ edition = "2018"
 [dependencies]
 sha3 = "0.8.2"
 rlp = "0.4.2"
-hex = "0.3.2"
+hex = "0.4.0"
 serde_json = "1.0.40"
-
-[dev-dependencies]
-hex = "0.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
             keyvals: proof.keyvals,
             instructions: proof.instructions,
         };
-        let new_root = rebuild(&proof).unwrap();
+        let new_root: Node = proof.rebuild().unwrap();
 
         assert_eq!(
             new_root,
@@ -432,9 +432,9 @@ mod tests {
 
         let proof = make_multiproof(&root, vec![NibbleKey::from(vec![2u8; 32])]).unwrap();
 
-        let res = proof.rebuild();
+        let res: Node = proof.rebuild().unwrap();
 
-        assert_eq!(res.unwrap().hash(), pre_root_hash);
+        assert_eq!(res.hash(), pre_root_hash);
     }
 
     #[test]
@@ -461,9 +461,9 @@ mod tests {
         ];
         let proof = make_multiproof(&root, keys).unwrap();
 
-        let res = proof.rebuild();
+        let res: Node = proof.rebuild().unwrap();
 
-        assert_eq!(res.unwrap().hash(), pre_root_hash);
+        assert_eq!(res.hash(), pre_root_hash);
     }
 
     #[test]
@@ -524,7 +524,7 @@ mod tests {
             ])],
             instructions: vec![LEAF(0)],
         };
-        let out = proof.rebuild().unwrap();
+        let out: Node = proof.rebuild().unwrap();
         assert_eq!(out, Leaf(NibbleKey::from(vec![]), vec![4, 5, 6]))
     }
 
@@ -538,7 +538,7 @@ mod tests {
             ])],
             instructions: vec![LEAF(0), BRANCH(0)],
         };
-        let out = proof.rebuild().unwrap();
+        let out: Node = proof.rebuild().unwrap();
         assert_eq!(
             out,
             Branch(vec![
@@ -572,7 +572,7 @@ mod tests {
             ],
             instructions: vec![LEAF(0), BRANCH(0), LEAF(1), ADD(2)],
         };
-        let out = proof.rebuild().unwrap();
+        let out: Node = proof.rebuild().unwrap();
         assert_eq!(
             out,
             Branch(vec![
@@ -612,7 +612,7 @@ mod tests {
                 rlp::encode_list::<Vec<u8>, Vec<u8>>(&vec![vec![7, 8, 9], vec![10, 11, 12]]),
             ],
         };
-        let out = proof.rebuild().unwrap();
+        let out: Node = proof.rebuild().unwrap();
         assert_eq!(
             out,
             Extension(
@@ -695,7 +695,7 @@ mod tests {
         );
         assert_eq!(proof.instructions.len(), 4);
 
-        let rebuilt = proof.rebuild().unwrap();
+        let rebuilt: Node = proof.rebuild().unwrap();
         assert_eq!(
             rebuilt,
             Branch(vec![
@@ -760,7 +760,7 @@ mod tests {
         assert_eq!(proof.keyvals.len(), 0);
         assert_eq!(proof.instructions.len(), 2);
 
-        let rebuilt = proof.rebuild().unwrap();
+        let rebuilt: Node = proof.rebuild().unwrap();
         assert_eq!(
             rebuilt,
             Extension(
@@ -806,7 +806,7 @@ mod tests {
         assert_eq!(proof.keyvals.len(), 1);
         assert_eq!(proof.instructions.len(), 6);
 
-        let rebuilt = proof.rebuild().unwrap();
+        let rebuilt: Node = proof.rebuild().unwrap();
         assert_eq!(
             rebuilt,
             Branch(vec![
@@ -843,7 +843,7 @@ mod tests {
         let missing_key = NibbleKey::from(vec![2u8; 32]);
 
         let proof = make_multiproof(&root, vec![missing_key.clone()]).unwrap();
-        let rebuilt = proof.rebuild().unwrap();
+        let rebuilt: Node = proof.rebuild().unwrap();
         assert!(!rebuilt.is_key_present(&missing_key));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,130 +111,6 @@ pub fn rebuild(proof: &Multiproof) -> Result<Node, String> {
         .ok_or(String::from("Stack underflow, expected root node"))
 }
 
-// Insert a `(key,value)` pair into a (sub-)tree represented by `root`.
-// It returns the root of the updated (sub-)tree.
-pub fn insert_leaf(root: &mut Node, key: &NibbleKey, value: Vec<u8>) -> Result<Node, String> {
-    use Node::*;
-
-    if key.len() == 0 {
-        return Err("Attempted to insert a 0-byte key".to_string());
-    }
-
-    match root {
-        Leaf(leafkey, leafvalue) => {
-            // Find the common part of the current key with that of the
-            // leaf and create an intermediate full node.
-            let firstdiffindex = leafkey.factor_length(key);
-
-            // Return an error if the leaf is already present.
-            if firstdiffindex == key.len() {
-                return Err(format!("Key is is already present!",));
-            }
-
-            // Create the new root, which is a full node.
-            let mut res = vec![EmptySlot; 16];
-            // Add the initial leaf, with a key truncated by the common
-            // key part.
-            res[leafkey[firstdiffindex] as usize] = Leaf(
-                NibbleKey::from(leafkey[firstdiffindex + 1..].to_vec()),
-                leafvalue.to_vec(),
-            );
-            // Add the node to be inserted
-            res[key[firstdiffindex] as usize] =
-                Leaf(NibbleKey::from(key[firstdiffindex + 1..].to_vec()), value);
-            // Put the common part into an extension node
-            if firstdiffindex == 0 {
-                // Special case: no extension necessary
-                Ok(Branch(res))
-            } else {
-                Ok(Extension(
-                    NibbleKey::from(key[..firstdiffindex].to_vec()),
-                    Box::new(Branch(res)),
-                ))
-            }
-        }
-        Extension(extkey, box child) => {
-            // Find the common part of the current key with that of the
-            // extension and create an intermediate full node.
-            let firstdiffindex = extkey.factor_length(&NibbleKey::from(key.clone()));
-
-            // Special case: key is longer than the extension key:
-            // recurse on the child node.
-            if firstdiffindex == extkey.len() {
-                let childroot = insert_leaf(
-                    &mut child.clone(),
-                    &NibbleKey::from(key[extkey.len()..].to_vec()),
-                    value,
-                )?;
-                return Ok(Extension(extkey.clone(), Box::new(childroot)));
-            }
-
-            // Special case: key is completely unlike the extension key
-            if firstdiffindex == 0 {
-                let mut res = vec![EmptySlot; 16];
-
-                // Create the entry for the truncated extension key
-                // Was it an extension of 1 ? If so, place the node directly
-                // otherwise truncate the extension.
-                res[extkey[0] as usize] = if extkey.len() == 1 {
-                    child.clone()
-                } else {
-                    Extension(
-                        NibbleKey::from(extkey[1..].to_vec()),
-                        Box::new(child.clone()),
-                    )
-                };
-
-                // Create the entry for the node. If there was only a
-                // difference of one byte, that byte will be consumed by
-                // the fullnode and therefore the key in the leaf will be
-                // an empty slice `[]`.
-                res[key[0] as usize] = Leaf(NibbleKey::from(key[1..].to_vec()), value);
-
-                return Ok(Branch(res));
-            }
-
-            // Create the new root, which is a full node.
-            let mut res = vec![EmptySlot; 16];
-            // Add the initial leaf, with a key truncated by the common
-            // key part. If the common part corresponds to the extension
-            // key length minus one, then there is no need for the creation
-            // of an extension node past the full node.
-            res[extkey[firstdiffindex] as usize] = if extkey.len() - firstdiffindex > 1 {
-                Extension(
-                    NibbleKey::from(extkey[firstdiffindex + 1..].to_vec()),
-                    Box::new(child.clone()),
-                )
-            } else {
-                child.clone()
-            };
-            // Add the node to be inserted
-            res[key[firstdiffindex] as usize] =
-                Leaf(NibbleKey::from(key[firstdiffindex + 1..].to_vec()), value);
-            // Put the common part into an extension node
-            Ok(Extension(
-                NibbleKey::from(extkey[..firstdiffindex].to_vec()),
-                Box::new(Branch(res)),
-            ))
-        }
-        Branch(ref mut vec) => {
-            let idx = key[0] as usize;
-            // If the slot isn't yet in use, fill it, and otherwise,
-            // recurse into the child node.
-            vec[idx] = if vec[idx] == EmptySlot {
-                // XXX check that the value is at least 1
-                Leaf(NibbleKey::from(key[1..].to_vec()), value)
-            } else {
-                insert_leaf(&mut vec[idx], &NibbleKey::from(key[1..].to_vec()), value)?
-            };
-            // Return the root node with an updated entry
-            Ok(Branch(vec.to_vec()))
-        }
-        EmptySlot => Ok(Leaf(key.clone(), value)),
-        _ => panic!("Can not insert a node into a hashed node"),
-    }
-}
-
 // Helper function that generates a multiproof based on one `(key.value)`
 // pair.
 pub fn make_multiproof(root: &Node, keys: Vec<NibbleKey>) -> Result<Multiproof, String> {
@@ -383,6 +259,7 @@ pub fn make_multiproof(root: &Node, keys: Vec<NibbleKey>) -> Result<Multiproof, 
 mod tests {
     extern crate hex;
 
+    use super::tree::*;
     use super::Instruction::*;
     use super::Node::*;
     use super::*;
@@ -391,9 +268,12 @@ mod tests {
     #[test]
     fn validate_tree() {
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![8u8; 32]), vec![150u8; 32]).unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![1u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![8u8; 32]), vec![150u8; 32])
+            .unwrap();
 
         let keys = vec![
             NibbleKey::from(vec![2u8; 32]),
@@ -438,9 +318,12 @@ mod tests {
     #[test]
     fn make_multiproof_two_values() {
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![8u8; 32]), vec![150u8; 32]).unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![1u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![8u8; 32]), vec![150u8; 32])
+            .unwrap();
 
         let proof = make_multiproof(
             &root,
@@ -491,8 +374,10 @@ mod tests {
     #[test]
     fn make_multiproof_single_value() {
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]).unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![1u8; 32])
+            .unwrap();
 
         let proof = make_multiproof(&root, vec![NibbleKey::from(vec![1u8; 32])]).unwrap();
         let i = proof.instructions;
@@ -524,8 +409,10 @@ mod tests {
     #[test]
     fn make_multiproof_no_values() {
         let mut root = Node::default();
-        insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![0u8; 32]).unwrap();
-        insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]).unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![1u8; 32])
+            .unwrap();
 
         let proof = make_multiproof(&root, vec![]).unwrap();
         let i = proof.instructions;
@@ -539,8 +426,10 @@ mod tests {
     #[test]
     fn make_multiproof_hash_before_nested_nodes_in_branch() {
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![0u8; 32]).unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![0u8; 32])
+            .unwrap();
 
         let pre_root_hash = root.hash();
 
@@ -564,7 +453,7 @@ mod tests {
         let mut root = Node::default();
         for i in &inputs {
             let k = nibble_from_hex(&i.0[2..]);
-            insert_leaf(&mut root, &k, i.1.clone()).unwrap();
+            root.insert(&k, i.1.clone()).unwrap();
         }
 
         let pre_root_hash = root.hash();
@@ -618,7 +507,7 @@ mod tests {
                 .append(&code)
                 .append(&storage_hash);
             let encoding = stream.out();
-            root = insert_leaf(&mut root, &NibbleKey::from(byte_key), encoding).unwrap();
+            root.insert(&NibbleKey::from(byte_key), encoding).unwrap();
         });
 
         let pre_root_hash = root.hash();
@@ -626,414 +515,6 @@ mod tests {
             hex::encode(pre_root_hash),
             "b3c418cb00ad7c907176be86a5a21759b74bd3828ed62a1ea2ae8daea98c5da2"
         );
-    }
-
-    #[test]
-    fn insert_leaf_zero_length_key_after_fullnode() {
-        let mut root = Extension(
-            NibbleKey::from(vec![0u8; 31]),
-            Box::new(Branch(vec![
-                EmptySlot,
-                Leaf(NibbleKey::from(vec![]), vec![0u8; 32]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-            ])),
-        );
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Extension(
-                NibbleKey::from(vec![0u8; 31]),
-                Box::new(Branch(vec![
-                    Leaf(NibbleKey::from(vec![]), vec![1u8; 32]),
-                    Leaf(NibbleKey::from(vec![]), vec![0u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot
-                ]))
-            )
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_extension_root_all_bytes_in_key_common() {
-        let mut root = Extension(
-            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
-            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
-        );
-        let mut key = vec![1u8; 32];
-        key[0] = 0xd;
-        key[1] = 0xe;
-        key[2] = 0xa;
-        key[3] = 0xd;
-        let out = insert_leaf(&mut root, &NibbleKey::from(key), vec![2u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Extension(
-                NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
-                Box::new(Branch(vec![
-                    Leaf(NibbleKey::from(vec![0u8; 27]), vec![1u8; 32]),
-                    Leaf(NibbleKey::from(vec![1u8; 27]), vec![2u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot
-                ]))
-            )
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_extension_root_no_common_bytes_in_key() {
-        let mut root = Extension(
-            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
-            Box::new(Leaf(NibbleKey::from(vec![0u8; 24]), vec![1u8; 32])),
-        );
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Branch(vec![
-                EmptySlot,
-                EmptySlot,
-                Leaf(NibbleKey::from(vec![2u8; 31]), vec![1u8; 32]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                Extension(
-                    NibbleKey::from(vec![14, 10, 13]),
-                    Box::new(Leaf(NibbleKey::from(vec![0u8; 24]), vec![1u8; 32]))
-                ),
-                EmptySlot,
-                EmptySlot
-            ])
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_extension_root_half_bytes_in_key_common() {
-        let mut root = Extension(
-            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
-            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
-        );
-        let mut key = vec![0u8; 32];
-        key[0] = 0xd;
-        key[1] = 0xe;
-        let out = insert_leaf(&mut root, &NibbleKey::from(key), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Extension(
-                NibbleKey::from(vec![0xd, 0xe]),
-                Box::new(Branch(vec![
-                    Leaf(NibbleKey::from(vec![0u8; 29]), vec![1u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    Extension(
-                        NibbleKey::from(vec![0xd]),
-                        Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]))
-                    ),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot
-                ]))
-            )
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_extension_root_almost_all_bytes_in_key_common() {
-        let mut root = Extension(
-            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
-            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
-        );
-        let mut key = vec![0u8; 32];
-        key[0] = 0xd;
-        key[1] = 0xe;
-        key[2] = 0xa;
-        let out = insert_leaf(&mut root, &NibbleKey::from(key), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Extension(
-                NibbleKey::from(vec![0xd, 0xe, 0xa]),
-                Box::new(Branch(vec![
-                    Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]),
-                    EmptySlot,
-                    EmptySlot
-                ]))
-            )
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_leaf_root_common_bytes_in_key() {
-        let mut key = vec![0u8; 32];
-        for (i, v) in key.iter_mut().enumerate() {
-            if i >= 16 {
-                break;
-            }
-            *v = 2u8;
-        }
-        let mut root = Leaf(NibbleKey::from(key), vec![1u8; 32]);
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Extension(
-                NibbleKey::from(vec![2u8; 16]),
-                Box::new(Branch(vec![
-                    Leaf(NibbleKey::from(vec![0u8; 15]), vec![1u8; 32]),
-                    EmptySlot,
-                    Leaf(NibbleKey::from(vec![2u8; 15]), vec![1u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot
-                ]))
-            )
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_leaf_root_no_common_bytes_in_key() {
-        let mut root = Leaf(NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]);
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            out,
-            Branch(vec![
-                EmptySlot,
-                Leaf(NibbleKey::from(vec![1u8; 31]), vec![1u8; 32]),
-                Leaf(NibbleKey::from(vec![2u8; 31]), vec![1u8; 32]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot
-            ])
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_emptyslot() {
-        let mut root = Node::default();
-        assert_eq!(root, EmptySlot);
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(out, Leaf(NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]));
-    }
-
-    #[test]
-    fn insert_two_leaves_into_emptyslot() {
-        let mut root = Node::default();
-        assert_eq!(root, EmptySlot);
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]).unwrap();
-        assert_eq!(
-            root,
-            Branch(vec![
-                Leaf(NibbleKey::from(vec![0u8; 31]), vec![1u8; 32]),
-                Leaf(NibbleKey::from(vec![1u8; 31]), vec![1u8; 32]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot
-            ])
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_empty_root() {
-        let children = vec![EmptySlot; 16];
-        let mut root = Branch(children);
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]);
-        assert_eq!(
-            out.unwrap(),
-            Branch(vec![
-                Leaf(NibbleKey::from(vec![0u8; 31]), vec![1u8; 32]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot
-            ])
-        );
-    }
-
-    #[test]
-    fn insert_leaf_into_two_level_fullnodes() {
-        let mut root = Branch(vec![
-            Branch(vec![EmptySlot; 16]),
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-            EmptySlot,
-        ]);
-        let out = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]);
-        assert_eq!(
-            out.unwrap(),
-            Branch(vec![
-                Branch(vec![
-                    Leaf(NibbleKey::from(vec![0u8; 30]), vec![1u8; 32]),
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot,
-                    EmptySlot
-                ]),
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot,
-                EmptySlot
-            ])
-        );
-    }
-
-    #[test]
-    fn insert_leaf_two_embedded_nodes() {
-        let expected_root =
-            hex::decode(&"0x1e1f73cc50d595585797d261df5be9bf69037a57e6470c9e4ffc87b6221ab67a"[2..])
-                .unwrap();
-        let inputs = [
-            ("0x1111111111111111111111111111111111111111", "0xffff"),
-            ("0x2222222222222222222222222222222222222222", "0xeeee"),
-        ];
-
-        let mut root = Branch(vec![EmptySlot; 16]);
-        for (ik, iv) in inputs.iter() {
-            let k = NibbleKey::from(utils::ByteKey(hex::decode(&ik[2..]).unwrap()));
-            let v = hex::decode(&iv[2..]).unwrap();
-            insert_leaf(&mut root, &k, v).unwrap();
-        }
-
-        let root_hash = root.hash();
-        assert_eq!(expected_root, root_hash);
     }
 
     #[test]
@@ -1164,38 +645,35 @@ mod tests {
     #[test]
     fn roundtrip() {
         let mut tree_root = Node::Branch(vec![Node::EmptySlot; 16]);
-        let new_root = insert_leaf(
-            &mut tree_root,
-            &NibbleKey::from(vec![1u8; 32]),
-            vec![2u8; 32],
-        )
-        .unwrap();
+        tree_root
+            .insert(&NibbleKey::from(vec![1u8; 32]), vec![2u8; 32])
+            .unwrap();
 
         assert_eq!(
-            new_root.hash(),
+            tree_root.hash(),
             vec![
                 86, 102, 96, 191, 106, 199, 70, 178, 131, 236, 157, 14, 50, 168, 100, 69, 123, 66,
                 223, 122, 0, 97, 18, 144, 20, 79, 250, 219, 73, 190, 134, 108
             ]
         );
 
-        let proof = make_multiproof(&new_root, vec![NibbleKey::from(vec![1u8; 32])]).unwrap();
+        let proof = make_multiproof(&tree_root, vec![NibbleKey::from(vec![1u8; 32])]).unwrap();
 
         // RLP roundtrip
         let proof_rlp = rlp::encode(&proof);
         let proof = rlp::decode(&proof_rlp).unwrap();
 
         let rebuilt_root = rebuild(&proof).unwrap();
-        assert_eq!(new_root, rebuilt_root);
+        assert_eq!(tree_root, rebuilt_root);
     }
 
     #[test]
     fn test_nullkey_leaf() {
         let missing_key = NibbleKey::from(vec![1u8; 32]);
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![0u8; 32]), vec![0u8; 32]).unwrap();
-        root = insert_leaf(
-            &mut root,
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![0u8; 32])
+            .unwrap();
+        root.insert(
             &NibbleKey::from(ByteKey::from(
                 hex::decode("11111111111111110000000000000000").unwrap(),
             )),
@@ -1259,16 +737,14 @@ mod tests {
     fn test_nullkey_ext() {
         let missing_key = NibbleKey::from(vec![1u8; 32]);
         let mut root = Node::default();
-        root = insert_leaf(
-            &mut root,
+        root.insert(
             &NibbleKey::from(ByteKey::from(
                 hex::decode("11111111111111182222222222222222").unwrap(),
             )),
             vec![0u8; 32],
         )
         .unwrap();
-        root = insert_leaf(
-            &mut root,
+        root.insert(
             &NibbleKey::from(ByteKey::from(
                 hex::decode("11111111111111180000000000000000").unwrap(),
             )),
@@ -1305,16 +781,14 @@ mod tests {
     fn test_nullkey_branch() {
         let missing_key = NibbleKey::from(vec![2u8; 32]);
         let mut root = Node::default();
-        root = insert_leaf(
-            &mut root,
+        root.insert(
             &NibbleKey::from(ByteKey::from(
                 hex::decode("11111111111111182222222222222222").unwrap(),
             )),
             vec![0u8; 32],
         )
         .unwrap();
-        root = insert_leaf(
-            &mut root,
+        root.insert(
             &NibbleKey::from(ByteKey::from(
                 hex::decode("01111111111111180000000000000000").unwrap(),
             )),
@@ -1388,9 +862,9 @@ mod tests {
         let k3 = &NibbleKey::from(ByteKey::from(
             hex::decode("00111111111111110000000000000000").unwrap(),
         ));
-        root = insert_leaf(&mut root, k1, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k2, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k3, vec![0u8; 32]).unwrap();
+        root.insert(k1, vec![0u8; 32]).unwrap();
+        root.insert(k2, vec![0u8; 32]).unwrap();
+        root.insert(k3, vec![0u8; 32]).unwrap();
 
         assert_eq!(
             root[&NibbleKey::from(&k2[..2])],
@@ -1410,9 +884,9 @@ mod tests {
         let k3 = &NibbleKey::from(ByteKey::from(
             hex::decode("11111111111111120000000000000000").unwrap(),
         ));
-        root = insert_leaf(&mut root, k1, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k2, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k3, vec![0u8; 32]).unwrap();
+        root.insert(k1, vec![0u8; 32]).unwrap();
+        root.insert(k2, vec![0u8; 32]).unwrap();
+        root.insert(k3, vec![0u8; 32]).unwrap();
 
         // check that a partial key returns the whole key
         assert_eq!(root[&NibbleKey::from(&k2[..2])], root);
@@ -1435,9 +909,9 @@ mod tests {
         let k3 = &NibbleKey::from(ByteKey::from(
             hex::decode("00111111111111110000000000000000").unwrap(),
         ));
-        root = insert_leaf(&mut root, k1, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k2, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k3, vec![0u8; 32]).unwrap();
+        root.insert(k1, vec![0u8; 32]).unwrap();
+        root.insert(k2, vec![0u8; 32]).unwrap();
+        root.insert(k3, vec![0u8; 32]).unwrap();
 
         assert_eq!(root[&NibbleKey::from(vec![])], root);
     }
@@ -1455,9 +929,9 @@ mod tests {
             hex::decode("11111111111111111111111111111111").unwrap(),
         ));
 
-        root = insert_leaf(&mut root, k1, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k2, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k3, vec![0u8; 32]).unwrap();
+        root.insert(k1, vec![0u8; 32]).unwrap();
+        root.insert(k2, vec![0u8; 32]).unwrap();
+        root.insert(k3, vec![0u8; 32]).unwrap();
 
         assert!(root.is_key_present(k1));
     }
@@ -1475,8 +949,8 @@ mod tests {
             hex::decode("11111111111111111111111111111111").unwrap(),
         ));
 
-        root = insert_leaf(&mut root, k2, vec![0u8; 32]).unwrap();
-        root = insert_leaf(&mut root, k3, vec![0u8; 32]).unwrap();
+        root.insert(k2, vec![0u8; 32]).unwrap();
+        root.insert(k3, vec![0u8; 32]).unwrap();
 
         assert!(!root.is_key_present(k1));
     }
@@ -1485,7 +959,8 @@ mod tests {
     fn check_payload_length_exactly_32_bytes() {
         let mut root = Node::default();
 
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 16]), vec![1u8; 20]).unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 16]), vec![1u8; 20])
+            .unwrap();
         assert_eq!(root.hash().len(), 32);
         assert_eq!(
             root.hash(),
@@ -1500,7 +975,8 @@ mod tests {
     fn check_leaf_length_less_than_32_bytes() {
         let mut root = Node::default();
 
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 2]), vec![1u8; 20]).unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 2]), vec![1u8; 20])
+            .unwrap();
         assert_eq!(
             root.composition(),
             vec![216, 130, 32, 17, 148, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
@@ -1517,8 +993,10 @@ mod tests {
     #[test]
     fn check_branch_less_than_32_bytes() {
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 4]), vec![1u8; 2]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![2u8; 4]), vec![1u8; 2]).unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 4]), vec![1u8; 2])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![2u8; 4]), vec![1u8; 2])
+            .unwrap();
 
         assert_eq!(
             root.composition(),
@@ -1542,8 +1020,10 @@ mod tests {
         second_key.extend(vec![2u8; 2]);
 
         let mut root = Node::default();
-        root = insert_leaf(&mut root, &NibbleKey::from(vec![1u8; 4]), vec![1u8; 2]).unwrap();
-        root = insert_leaf(&mut root, &NibbleKey::from(second_key), vec![1u8; 2]).unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 4]), vec![1u8; 2])
+            .unwrap();
+        root.insert(&NibbleKey::from(second_key), vec![1u8; 2])
+            .unwrap();
 
         assert_eq!(
             root.composition(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate sha3;
 pub mod instruction;
 pub mod multiproof;
 pub mod node;
+pub mod tree;
 pub mod utils;
 
 use instruction::*;

--- a/src/multiproof.rs
+++ b/src/multiproof.rs
@@ -1,4 +1,10 @@
 use super::instruction::*;
+use super::tree::{KeyValueStore, Tree};
+
+pub trait ProofToTree<S: KeyValueStore, T: Tree<S>> {
+    /// Rebuilds a tree of type `T` based on the proof's components.
+    fn rebuild(&self) -> Result<T, String>;
+}
 
 #[derive(Debug, PartialEq)]
 pub struct Multiproof {

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,12 +3,12 @@ extern crate sha3;
 use super::utils::*;
 use sha3::{Digest, Keccak256};
 
-pub struct ChildIterator<'a, T: Tree + ?Sized> {
+pub struct NodeChildIterator<'a> {
     index: usize,
-    node: &'a T,
+    node: &'a Node,
 }
 
-impl<'a> std::iter::Iterator for ChildIterator<'a, Node> {
+impl<'a> std::iter::Iterator for NodeChildIterator<'a> {
     type Item = Node;
 
     #[inline]
@@ -55,7 +55,8 @@ pub trait Tree {
     type Value;
     fn is_leaf(&self) -> bool;
     fn is_empty(&self) -> bool;
-    fn children(&self) -> ChildIterator<dyn Tree<Key = Self::Key, Value = Self::Value>>;
+    //fn children(&self) -> ChildIterator<dyn Tree<Key = Self::Key, Value = Self::Value>>;
+    fn children(&self) -> dyn Iterator<Item = Self>;
     fn insert(&mut self, key: &Self::Key, value: Self::Value) -> Result<(), String>;
 }
 
@@ -86,21 +87,21 @@ impl Tree for Node {
         }
     }
 
-    fn children(&self) -> ChildIterator<dyn Tree<Key = NibbleKey, Value = Vec<u8>>> {
+    fn children(&self) -> dyn Iterator<Item = Node> {
         match self {
-            Node::EmptySlot => ChildIterator {
+            Node::EmptySlot => NodeChildIterator {
                 index: 0,
                 node: self,
             },
-            Node::Leaf(_, _) => ChildIterator {
+            Node::Leaf(_, _) => NodeChildIterator {
                 index: 0,
                 node: self,
             },
-            Node::Extension(_, _) => ChildIterator {
+            Node::Extension(_, _) => NodeChildIterator {
                 index: 0,
                 node: self,
             },
-            Node::Branch(_) => ChildIterator {
+            Node::Branch(_) => NodeChildIterator {
                 index: 0,
                 node: self,
             },

--- a/src/node.rs
+++ b/src/node.rs
@@ -299,9 +299,7 @@ impl rlp::Decodable for Node {
             return Err(rlp::DecoderError::RlpExpectedToBeList);
         }
         let keyval = rlp.as_list::<Vec<u8>>()?;
-        let key_bytes = ByteKey(keyval[0].clone());
-        let key_nibbles = NibbleKey::from(key_bytes);
-        // TODO: remove indicator prefix if node is a leaf or extension
+        let key_nibbles = NibbleKey::remove_hex_prefix(&keyval[0]);
         Ok(Node::Leaf(key_nibbles, keyval[1].clone()))
     }
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -3,6 +3,11 @@ extern crate sha3;
 use super::utils::*;
 use sha3::{Digest, Keccak256};
 
+pub trait Tree<K, V> {
+    fn is_leaf(&self) -> bool;
+    fn insert(&mut self, key: &K, value: V) -> Result<(), String>;
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Node {
     Hash(Vec<u8>),
@@ -10,6 +15,139 @@ pub enum Node {
     Extension(NibbleKey, Box<Node>),
     Branch(Vec<Node>),
     EmptySlot,
+}
+
+impl Tree<NibbleKey, Vec<u8>> for Node {
+    fn is_leaf(&self) -> bool {
+        match self {
+            Node::Leaf(_, _) => true,
+            _ => false,
+        }
+    }
+
+    fn insert(&mut self, key: &NibbleKey, value: Vec<u8>) -> Result<(), String> {
+        use Node::*;
+
+        if key.len() == 0 {
+            return Err("Attempted to insert a 0-byte key".to_string());
+        }
+
+        match self {
+            Leaf(leafkey, leafvalue) => {
+                // Find the common part of the current key with that of the
+                // leaf and create an intermediate full node.
+                let firstdiffindex = leafkey.factor_length(key);
+
+                // Return an error if the leaf is already present.
+                if firstdiffindex == key.len() {
+                    return Err(format!("Key is is already present!",));
+                }
+
+                // Create the new root, which is a full node.
+                let mut res = vec![EmptySlot; 16];
+                // Add the initial leaf, with a key truncated by the common
+                // key part.
+                res[leafkey[firstdiffindex] as usize] = Leaf(
+                    NibbleKey::from(leafkey[firstdiffindex + 1..].to_vec()),
+                    leafvalue.to_vec(),
+                );
+                // Add the node to be inserted
+                res[key[firstdiffindex] as usize] =
+                    Leaf(NibbleKey::from(key[firstdiffindex + 1..].to_vec()), value);
+                // Put the common part into an extension node
+                *self = if firstdiffindex == 0 {
+                    // Special case: no extension necessary
+                    Branch(res)
+                } else {
+                    Extension(
+                        NibbleKey::from(key[..firstdiffindex].to_vec()),
+                        Box::new(Branch(res)),
+                    )
+                };
+                Ok(())
+            }
+            Extension(extkey, box child) => {
+                // Find the common part of the current key with that of the
+                // extension and create an intermediate full node.
+                let firstdiffindex = extkey.factor_length(&NibbleKey::from(key.clone()));
+
+                // Special case: key is longer than the extension key:
+                // recurse on the child node.
+                if firstdiffindex == extkey.len() {
+                    child.insert(&NibbleKey::from(key[extkey.len()..].to_vec()), value)?;
+                    return Ok(());
+                }
+
+                // Special case: key is completely unlike the extension key
+                if firstdiffindex == 0 {
+                    let mut res = vec![EmptySlot; 16];
+
+                    // Create the entry for the truncated extension key
+                    // Was it an extension of 1 ? If so, place the node directly
+                    // otherwise truncate the extension.
+                    res[extkey[0] as usize] = if extkey.len() == 1 {
+                        child.clone()
+                    } else {
+                        Extension(
+                            NibbleKey::from(extkey[1..].to_vec()),
+                            Box::new(child.clone()),
+                        )
+                    };
+
+                    // Create the entry for the node. If there was only a
+                    // difference of one byte, that byte will be consumed by
+                    // the fullnode and therefore the key in the leaf will be
+                    // an empty slice `[]`.
+                    res[key[0] as usize] = Leaf(NibbleKey::from(key[1..].to_vec()), value);
+
+                    *self = Branch(res);
+                    return Ok(());
+                }
+
+                // Create the new root, which is a full node.
+                let mut res = vec![EmptySlot; 16];
+                // Add the initial leaf, with a key truncated by the common
+                // key part. If the common part corresponds to the extension
+                // key length minus one, then there is no need for the creation
+                // of an extension node past the full node.
+                res[extkey[firstdiffindex] as usize] = if extkey.len() - firstdiffindex > 1 {
+                    Extension(
+                        NibbleKey::from(extkey[firstdiffindex + 1..].to_vec()),
+                        Box::new(child.clone()),
+                    )
+                } else {
+                    child.clone()
+                };
+                // Add the node to be inserted
+                res[key[firstdiffindex] as usize] =
+                    Leaf(NibbleKey::from(key[firstdiffindex + 1..].to_vec()), value);
+                // Put the common part into an extension node
+                *self = Extension(
+                    NibbleKey::from(extkey[..firstdiffindex].to_vec()),
+                    Box::new(Branch(res)),
+                );
+                Ok(())
+            }
+            Branch(ref mut vec) => {
+                let idx = key[0] as usize;
+                // If the slot isn't yet in use, fill it, and otherwise,
+                // recurse into the child node.
+                if vec[idx] == EmptySlot {
+                    // XXX check that the value is at least 1
+                    vec[idx] = Leaf(NibbleKey::from(key[1..].to_vec()), value);
+                } else {
+                    vec[idx].insert(&NibbleKey::from(key[1..].to_vec()), value)?;
+                }
+                // Return the root node with an updated entry
+                Ok(())
+            }
+            EmptySlot => {
+                *self = Leaf(key.clone(), value);
+                Ok(())
+            }
+            _ => panic!("Can not insert a node into a hashed node"),
+        }
+    }
 }
 
 impl Default for Node {
@@ -268,6 +406,7 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
+    use super::super::utils;
     use super::Node::*;
     use super::*;
 
@@ -353,5 +492,422 @@ mod tests {
                 51, 53, 12, 149, 35, 120, 93, 254, 247, 104, 88, 103, 177
             ]
         );
+    }
+
+    #[test]
+    fn insert_leaf_zero_length_key_after_fullnode() {
+        let mut root = Extension(
+            NibbleKey::from(vec![0u8; 31]),
+            Box::new(Branch(vec![
+                EmptySlot,
+                Leaf(NibbleKey::from(vec![]), vec![0u8; 32]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+            ])),
+        );
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Extension(
+                NibbleKey::from(vec![0u8; 31]),
+                Box::new(Branch(vec![
+                    Leaf(NibbleKey::from(vec![]), vec![1u8; 32]),
+                    Leaf(NibbleKey::from(vec![]), vec![0u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot
+                ]))
+            )
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_extension_root_all_bytes_in_key_common() {
+        let mut root = Extension(
+            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
+            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
+        );
+        let mut key = vec![1u8; 32];
+        key[0] = 0xd;
+        key[1] = 0xe;
+        key[2] = 0xa;
+        key[3] = 0xd;
+        root.insert(&NibbleKey::from(key), vec![2u8; 32]).unwrap();
+        assert_eq!(
+            root,
+            Extension(
+                NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
+                Box::new(Branch(vec![
+                    Leaf(NibbleKey::from(vec![0u8; 27]), vec![1u8; 32]),
+                    Leaf(NibbleKey::from(vec![1u8; 27]), vec![2u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot
+                ]))
+            )
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_extension_root_no_common_bytes_in_key() {
+        let mut root = Extension(
+            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
+            Box::new(Leaf(NibbleKey::from(vec![0u8; 24]), vec![1u8; 32])),
+        );
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Branch(vec![
+                EmptySlot,
+                EmptySlot,
+                Leaf(NibbleKey::from(vec![2u8; 31]), vec![1u8; 32]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                Extension(
+                    NibbleKey::from(vec![14, 10, 13]),
+                    Box::new(Leaf(NibbleKey::from(vec![0u8; 24]), vec![1u8; 32]))
+                ),
+                EmptySlot,
+                EmptySlot
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_extension_root_half_bytes_in_key_common() {
+        let mut root = Extension(
+            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
+            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
+        );
+        let mut key = vec![0u8; 32];
+        key[0] = 0xd;
+        key[1] = 0xe;
+        root.insert(&NibbleKey::from(key), vec![1u8; 32]).unwrap();
+        assert_eq!(
+            root,
+            Extension(
+                NibbleKey::from(vec![0xd, 0xe]),
+                Box::new(Branch(vec![
+                    Leaf(NibbleKey::from(vec![0u8; 29]), vec![1u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    Extension(
+                        NibbleKey::from(vec![0xd]),
+                        Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]))
+                    ),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot
+                ]))
+            )
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_extension_root_almost_all_bytes_in_key_common() {
+        let mut root = Extension(
+            NibbleKey::from(vec![0xd, 0xe, 0xa, 0xd]),
+            Box::new(Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32])),
+        );
+        let mut key = vec![0u8; 32];
+        key[0] = 0xd;
+        key[1] = 0xe;
+        key[2] = 0xa;
+        root.insert(&NibbleKey::from(key), vec![1u8; 32]).unwrap();
+        assert_eq!(
+            root,
+            Extension(
+                NibbleKey::from(vec![0xd, 0xe, 0xa]),
+                Box::new(Branch(vec![
+                    Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    Leaf(NibbleKey::from(vec![0u8; 28]), vec![1u8; 32]),
+                    EmptySlot,
+                    EmptySlot
+                ]))
+            )
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_leaf_root_common_bytes_in_key() {
+        let mut key = vec![0u8; 32];
+        for (i, v) in key.iter_mut().enumerate() {
+            if i >= 16 {
+                break;
+            }
+            *v = 2u8;
+        }
+        let mut root = Leaf(NibbleKey::from(key), vec![1u8; 32]);
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Extension(
+                NibbleKey::from(vec![2u8; 16]),
+                Box::new(Branch(vec![
+                    Leaf(NibbleKey::from(vec![0u8; 15]), vec![1u8; 32]),
+                    EmptySlot,
+                    Leaf(NibbleKey::from(vec![2u8; 15]), vec![1u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot
+                ]))
+            )
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_leaf_root_no_common_bytes_in_key() {
+        let mut root = Leaf(NibbleKey::from(vec![1u8; 32]), vec![1u8; 32]);
+        root.insert(&NibbleKey::from(vec![2u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Branch(vec![
+                EmptySlot,
+                Leaf(NibbleKey::from(vec![1u8; 31]), vec![1u8; 32]),
+                Leaf(NibbleKey::from(vec![2u8; 31]), vec![1u8; 32]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_emptyslot() {
+        let mut root = Node::default();
+        assert_eq!(root, EmptySlot);
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(root, Leaf(NibbleKey::from(vec![0u8; 32]), vec![1u8; 32]));
+    }
+
+    #[test]
+    fn insert_two_leaves_into_emptyslot() {
+        let mut root = Node::default();
+        assert_eq!(root, EmptySlot);
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![1u8; 32])
+            .unwrap();
+        root.insert(&NibbleKey::from(vec![1u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Branch(vec![
+                Leaf(NibbleKey::from(vec![0u8; 31]), vec![1u8; 32]),
+                Leaf(NibbleKey::from(vec![1u8; 31]), vec![1u8; 32]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_empty_root() {
+        let children = vec![EmptySlot; 16];
+        let mut root = Branch(children);
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Branch(vec![
+                Leaf(NibbleKey::from(vec![0u8; 31]), vec![1u8; 32]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_leaf_into_two_level_fullnodes() {
+        let mut root = Branch(vec![
+            Branch(vec![EmptySlot; 16]),
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+            EmptySlot,
+        ]);
+        root.insert(&NibbleKey::from(vec![0u8; 32]), vec![1u8; 32])
+            .unwrap();
+        assert_eq!(
+            root,
+            Branch(vec![
+                Branch(vec![
+                    Leaf(NibbleKey::from(vec![0u8; 30]), vec![1u8; 32]),
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot,
+                    EmptySlot
+                ]),
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot,
+                EmptySlot
+            ])
+        );
+    }
+
+    #[test]
+    fn insert_leaf_two_embedded_nodes() {
+        let expected_root =
+            hex::decode(&"0x1e1f73cc50d595585797d261df5be9bf69037a57e6470c9e4ffc87b6221ab67a"[2..])
+                .unwrap();
+        let inputs = [
+            ("0x1111111111111111111111111111111111111111", "0xffff"),
+            ("0x2222222222222222222222222222222222222222", "0xeeee"),
+        ];
+
+        let mut root = Branch(vec![EmptySlot; 16]);
+        for (ik, iv) in inputs.iter() {
+            let k = NibbleKey::from(utils::ByteKey(hex::decode(&ik[2..]).unwrap()));
+            let v = hex::decode(&iv[2..]).unwrap();
+            root.insert(&k, v).unwrap();
+        }
+
+        let root_hash = root.hash();
+        assert_eq!(expected_root, root_hash);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,17 +1,21 @@
-use super::utils::*;
-
-pub struct NodeChildIterator<'a, K, V> {
+pub struct NodeChildIterator<'a, S: KeyValueStore, T: Tree<S>> {
+    /// The iterator's current child index.
     pub index: usize,
-    pub node: &'a dyn Tree<Key = K, Value = V>,
+    /// The node's current key, if available.
+    pub key: Option<&'a S::Key>,
+    /// The node whose children are being iterated on.
+    pub node: &'a T,
 }
 
-/// A trait representing the an underlying tree structure.
-pub trait Tree {
+pub trait KeyValueStore {
     /// The tree's key type. Must be specified when implementing this trait.
     type Key;
     /// The tree's value type. Must be specified when implementing this trait.
     type Value;
+}
 
+/// A trait representing the an underlying tree structure.
+pub trait Tree<S: KeyValueStore>: Sized {
     /// Specifies if the current tree is a simple leaf.
     fn is_leaf(&self) -> bool;
     /// Specifies if the current tree is empty.
@@ -19,15 +23,26 @@ pub trait Tree {
     /// Returns the tree root's *maximal* number of children.
     fn num_children(&self) -> usize;
     /// Returns a pointer to child #i, or `None` if no such child exists.
-    fn ith_child(&self, index: usize) -> Option<&dyn Tree<Key = Self::Key, Value = Self::Value>>;
+    fn ith_child(&self, index: usize) -> Option<&Self>;
+    /// Set child node #i of the current node.
+    fn set_ith_child(&mut self, index: usize, child: &Self);
     /// Returns an iterator to the node's children. Some of these nodes can be empty.
-    fn children(&self) -> NodeChildIterator<Self::Key, Self::Value>;
+    fn children(&self) -> NodeChildIterator<S, Self>;
     /// Insert a `(key,value)` pair into a (sub-)tree represented by `root`.
-    fn insert(&mut self, key: &Self::Key, value: Self::Value) -> Result<(), String>;
+    fn insert(&mut self, key: &S::Key, value: S::Value) -> Result</* TODO &mut self */ (), String>;
+
+    fn value(&self) -> Option<&S::Value>;
+    fn value_length(&self) -> Option<usize>;
+
+    fn from_hash(h: Vec<u8>) -> Self;
+    fn new_empty() -> Self;
+    fn new_extension(ext: Vec<u8>, child: Self) -> Self;
+    fn new_branch() -> Self;
+    fn new_leaf(key: Vec<u8>, value: Vec<u8>) -> Self;
 }
 
-impl<'a> std::iter::Iterator for NodeChildIterator<'a, NibbleKey, Vec<u8>> {
-    type Item = &'a dyn Tree<Key = NibbleKey, Value = Vec<u8>>;
+impl<'a, S: KeyValueStore, T: Tree<S>> std::iter::Iterator for NodeChildIterator<'a, S, T> {
+    type Item = &'a T;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -22,6 +22,7 @@ pub trait Tree {
     fn ith_child(&self, index: usize) -> Option<&dyn Tree<Key = Self::Key, Value = Self::Value>>;
     /// Returns an iterator to the node's children. Some of these nodes can be empty.
     fn children(&self) -> NodeChildIterator<Self::Key, Self::Value>;
+    /// Insert a `(key,value)` pair into a (sub-)tree represented by `root`.
     fn insert(&mut self, key: &Self::Key, value: Self::Value) -> Result<(), String>;
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,0 +1,40 @@
+use super::utils::*;
+
+pub struct NodeChildIterator<'a, K, V> {
+    pub index: usize,
+    pub node: &'a dyn Tree<Key = K, Value = V>,
+}
+
+/// A trait representing the an underlying tree structure.
+pub trait Tree {
+    /// The tree's key type. Must be specified when implementing this trait.
+    type Key;
+    /// The tree's value type. Must be specified when implementing this trait.
+    type Value;
+
+    /// Specifies if the current tree is a simple leaf.
+    fn is_leaf(&self) -> bool;
+    /// Specifies if the current tree is empty.
+    fn is_empty(&self) -> bool;
+    /// Returns the tree root's *maximal* number of children.
+    fn num_children(&self) -> usize;
+    /// Returns a pointer to child #i, or `None` if no such child exists.
+    fn ith_child(&self, index: usize) -> Option<&dyn Tree<Key = Self::Key, Value = Self::Value>>;
+    /// Returns an iterator to the node's children. Some of these nodes can be empty.
+    fn children(&self) -> NodeChildIterator<Self::Key, Self::Value>;
+    fn insert(&mut self, key: &Self::Key, value: Self::Value) -> Result<(), String>;
+}
+
+impl<'a> std::iter::Iterator for NodeChildIterator<'a, NibbleKey, Vec<u8>> {
+    type Item = &'a dyn Tree<Key = NibbleKey, Value = Vec<u8>>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index < self.node.num_children() {
+            self.index += 1;
+            self.node.ith_child(self.index - 1)
+        } else {
+            None
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,33 @@ impl NibbleKey {
 
         output
     }
+
+    pub fn remove_hex_prefix(payload: &Vec<u8>) -> NibbleKey {
+        if payload.len() == 0 {
+            return NibbleKey(payload.clone());
+        }
+        match payload[0] {
+            x if x & 16 == 16 => {
+                // Odd payload.len()
+                let mut out = vec![0u8; (payload.len() - 1) * 2 + 1];
+                out[0] = x & 0xF;
+                for i in 1..payload.len() {
+                    out[2 * i - 1] = payload[i] >> 4;
+                    out[2 * i] = payload[i] & 0xF;
+                }
+                NibbleKey(out)
+            }
+            _ => {
+                // Even payload.len()
+                let mut out = vec![0u8; (payload.len() - 1) * 2];
+                for i in 1..payload.len() {
+                    out[2 * (i - 1)] = payload[i - 1] & 0xF;
+                    out[2 * (i - 1) + 1] = payload[i] >> 4;
+                }
+                NibbleKey(out)
+            }
+        }
+    }
 }
 
 impl rlp::Encodable for NibbleKey {


### PR DESCRIPTION
This PR prepares the ground for supporting several tree formats. This addresses #10 and supersedes #42 and #43

 * It adds a `Tree` trait that supports operations like insertion and iteration over the set of child nodes, then re-implements Node in terms of this trait.
 * This trait is parameterized by another trait, describing the key and value formats by requiring the definition of the `Key` and `Value` types, making is easier to switch between a nibble-/byte-/binary-based key type.
 * The `Multiproof` structure is parameterized by the tree type, to be able to reconstruct different types of trees from a single proof type.
 * It makes `rebuild` a method of `Multiproof`, which is the first step in supporting different proof types (the end goal is to support proofs that use instructions and proofs that do not)
 * It also effectively deprecates the use of the  `LEAF(i)` operand *i* as expressed in #19 