### PR TITLE
Binary key support + key trait

### DIFF
--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -14,7 +14,7 @@ use super::Key;
 ///
 /// ```
 /// use multiproof_rs::keys::BinaryKey;
-/// let bitkey = BinaryKey(vec![0x55; 2], 3, 6);
+/// let bitkey = BinaryKey::new(vec![0x55; 2], 3, 6);
 /// ```
 ///
 /// The internal representation is therefore:
@@ -28,7 +28,13 @@ use super::Key;
 ///           |   start  end
 /// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct BinaryKey(pub Vec<u8>, pub usize, pub usize); // (key data, offset in first byte, offset in last byte)
+pub struct BinaryKey(Vec<u8>, usize, usize); // (key data, offset in first byte, offset in last byte)
+
+impl BinaryKey {
+    pub fn new(data: Vec<u8>, start: usize, end: usize) -> Self {
+        BinaryKey(data, start, end)
+    }
+}
 
 impl From<Vec<u8>> for BinaryKey {
     fn from(bytes: Vec<u8>) -> Self {

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -10,24 +10,16 @@ impl From<Vec<u8>> for BinaryKey {
 }
 
 impl Key<u8> for BinaryKey {
-    fn head_and_tail(&self) -> (Option<u8>, Self) {
+    fn tail(&self) -> Self {
         if self.0.is_empty() {
-            return (None, BinaryKey(vec![], 7, 0));
+            return BinaryKey(vec![], 7, 0);
         }
 
         // Last bit in the byte?
         if self.1 == 0usize {
-            let next_bit = self.0[0] & (1 << self.1);
-            (
-                Some(next_bit),
-                BinaryKey(self.0[1..].to_vec(), 7usize, self.2),
-            )
+                BinaryKey(self.0[1..].to_vec(), 7usize, self.2)
         } else {
-            let next_bit = self.0[0] & (1 << self.1);
-            (
-                Some(next_bit),
-                BinaryKey(self.0.clone(), self.1 - 1, self.2),
-            )
+                BinaryKey(self.0.clone(), self.1 - 1, self.2)
         }
     }
 
@@ -79,8 +71,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            assert!(head.unwrap() != 0);
+            let tail = key.tail();
             key = tail;
             count += 1;
             if key.is_empty() {
@@ -99,8 +90,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            assert!(head.unwrap() != 0);
+            let tail = key.tail();
             key = tail;
             count += 1;
             if key.is_empty() {
@@ -119,8 +109,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            assert_eq!(head, None);
+            let tail = key.tail();
             assert_eq!(key.len(), 0);
             key = tail;
             count += 1;
@@ -140,12 +129,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            if count % 2 == 0 {
-                assert_eq!(head.unwrap(), 0);
-            } else {
-                assert!(head.unwrap() != 0);
-            }
+            let tail = key.tail();
             key = tail;
             count += 1;
             if key.is_empty() {
@@ -169,8 +153,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            assert!(head.unwrap() != 0);
+            let tail = key.tail();
             key = tail;
             count += 1;
             if key.is_empty() {
@@ -194,8 +177,7 @@ mod tests {
 
         let mut count = 0u32;
         loop {
-            let (head, tail) = key.head_and_tail();
-            assert!(head.unwrap() == 0);
+            let tail = key.tail();
             key = tail;
             count += 1;
             if key.is_empty() {

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -17,9 +17,9 @@ impl Key<u8> for BinaryKey {
 
         // Last bit in the byte?
         if self.1 == 0usize {
-                BinaryKey(self.0[1..].to_vec(), 7usize, self.2)
+            BinaryKey(self.0[1..].to_vec(), 7usize, self.2)
         } else {
-                BinaryKey(self.0.clone(), self.1 - 1, self.2)
+            BinaryKey(self.0.clone(), self.1 - 1, self.2)
         }
     }
 
@@ -232,5 +232,19 @@ mod tests {
             let bit = ((0xF0F0F0u32 >> i) & 1) as u8;
             assert_eq!(key[i], bit);
         }
+    }
+
+    #[test]
+    fn test_bit_index_one_bit() {
+        let key = BinaryKey(vec![0xFu8], 3, 3);
+        assert_eq!(key[0], 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid index 0 into key")]
+    fn test_bit_index_no_bits() {
+        let key = BinaryKey(vec![0xFu8], 3, 4);
+
+        key[0];
     }
 }

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -11,7 +11,7 @@ impl From<Vec<u8>> for BinaryKey {
 
 impl Key<u8> for BinaryKey {
     fn head_and_tail(&self) -> (Option<u8>, Self) {
-        if self.0.len() == 0 {
+        if self.0.is_empty() {
             return (None, BinaryKey(vec![], 7, 0));
         }
 

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -1,7 +1,34 @@
 use super::Key;
 
+/// Represents a key whose basic unit is the bit. This is meant to be
+/// used at the key in binary trees.
+///
+/// Bits are stored inside an array of bytes, and are read left to
+/// right. The structure also contains the start and end offset of
+/// the bit field.
+///
+/// # Example structure
+///
+/// The following code will create a bit field with 6 bits spread
+/// over two integers.
+///
+/// ```
+/// use multiproof_rs::keys::BinaryKey;
+/// let bitkey = BinaryKey(vec![0x55; 2], 3, 6);
+/// ```
+///
+/// The internal representation is therefore:
+///
+/// ```text
+/// byte #    |     1        2
+/// bit  #    | 76543210 76543210
+/// ----------+------------------
+/// bit value | 01010101 01010101
+/// offsets   |     ^     ^
+///           |   start  end
+/// ```
 #[derive(Debug, PartialEq, Clone)]
-pub struct BinaryKey(Vec<u8>, usize, usize); // (key data, offset in first byte, offset in last byte)
+pub struct BinaryKey(pub Vec<u8>, pub usize, pub usize); // (key data, offset in first byte, offset in last byte)
 
 impl From<Vec<u8>> for BinaryKey {
     fn from(bytes: Vec<u8>) -> Self {

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -1,0 +1,184 @@
+use super::Key;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BinaryKey(Vec<u8>, usize, usize); // (key data, offset in first byte, offset in last byte)
+
+impl From<Vec<u8>> for BinaryKey {
+    fn from(bytes: Vec<u8>) -> Self {
+        BinaryKey(bytes, 7usize, 0usize)
+    }
+}
+
+impl Key<u8> for BinaryKey {
+    fn head_and_tail(&self) -> (Option<u8>, Self) {
+        if self.0.len() == 0 {
+            return (None, BinaryKey(vec![], 7, 0));
+        }
+
+        // Last bit in the byte?
+        if self.1 == 0usize {
+            let next_bit = self.0[0] & (1 << self.1);
+            (
+                Some(next_bit),
+                BinaryKey(self.0[1..].to_vec(), 7usize, self.2),
+            )
+        } else {
+            let next_bit = self.0[0] & (1 << self.1);
+            (
+                Some(next_bit),
+                BinaryKey(self.0.clone(), self.1 - 1, self.2),
+            )
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self.0.len() {
+            0 => 0,
+            _ => (self.0.len() - 1) * 8 + self.1 + 1 - self.2,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.len() == 0 || (self.0.len() == 1 && self.1 < self.2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iterate_over_one_byte() {
+        let mut key = BinaryKey::from(vec![0xFFu8]);
+
+        assert_eq!(key.len(), 8);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            assert!(head.unwrap() != 0);
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 8);
+        }
+        assert_eq!(count, 8);
+    }
+
+    #[test]
+    fn test_iterate_over_two_bytes() {
+        let mut key = BinaryKey::from(vec![0xFFu8, 0xFFu8]);
+
+        assert_eq!(key.len(), 16);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            assert!(head.unwrap() != 0);
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 16);
+        }
+        assert_eq!(count, 16);
+    }
+
+    #[test]
+    fn test_iterate_over_zero_bytes() {
+        let mut key = BinaryKey::from(vec![]);
+
+        assert_eq!(key.len(), 0);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            assert_eq!(head, None);
+            assert_eq!(key.len(), 0);
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 2);
+        }
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_iterate_endianness() {
+        let mut key = BinaryKey::from(vec![0x55u8, 0x55u8]);
+
+        assert_eq!(key.len(), 16);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            if count % 2 == 0 {
+                assert_eq!(head.unwrap(), 0);
+            } else {
+                assert!(head.unwrap() != 0);
+            }
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 16);
+        }
+        assert_eq!(count, 16);
+    }
+
+    #[test]
+    fn test_unaligned_bitfield() {
+        // 8 bit total:
+        // offset   | 76543210 76543210
+        // ---------+------------------
+        // bit      | 01011111 11110101
+        // pointers |     ^       ^
+        let mut key = BinaryKey(vec![0x5Fu8, 0xF5u8], 3, 4);
+
+        assert_eq!(key.len(), 8);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            assert!(head.unwrap() != 0);
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 8);
+        }
+        assert_eq!(count, 8);
+    }
+
+    #[test]
+    fn test_unaligned_bitfield_one_byte() {
+        // 4 bit total:
+        // offset   | 76543210
+        // ---------+---------
+        // bit      | 10000111
+        // pointers |  ^  ^
+        let mut key = BinaryKey(vec![0x87u8], 6, 3);
+
+        assert_eq!(key.len(), 4);
+
+        let mut count = 0u32;
+        loop {
+            let (head, tail) = key.head_and_tail();
+            assert!(head.unwrap() == 0);
+            key = tail;
+            count += 1;
+            if key.is_empty() {
+                break;
+            }
+            assert!(count < 4);
+        }
+        assert_eq!(count, 4);
+    }
+}

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -39,3 +39,11 @@ impl Key<u8> for ByteKey {
         self.0.is_empty()
     }
 }
+
+impl std::ops::Index<usize> for ByteKey {
+    type Output = u8;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.0[i]
+    }
+}

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -23,12 +23,12 @@ impl From<ByteKey> for NibbleKey {
 }
 
 impl Key<u8> for ByteKey {
-    fn head_and_tail(&self) -> (Option<u8>, Self) {
+    fn tail(&self) -> Self {
         if self.0.is_empty() {
-            return (None, ByteKey(self.0.clone()));
+            return ByteKey(self.0.clone());
         }
 
-        (Some(self.0[0]), ByteKey::from(self.0[1..].to_vec()))
+         ByteKey::from(self.0[1..].to_vec())
     }
 
     fn len(&self) -> usize {

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -1,0 +1,41 @@
+use super::super::NibbleKey;
+use super::Key;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ByteKey(pub Vec<u8>);
+
+impl From<Vec<u8>> for ByteKey {
+    fn from(bytes: Vec<u8>) -> Self {
+        ByteKey(bytes)
+    }
+}
+
+impl From<ByteKey> for NibbleKey {
+    fn from(address: ByteKey) -> Self {
+        let mut nibbles = Vec::new();
+        for nibble in 0..2 * address.0.len() {
+            let nibble_shift = (1 - nibble % 2) * 4;
+
+            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
+        }
+        NibbleKey::from(nibbles)
+    }
+}
+
+impl Key<u8> for ByteKey {
+    fn head_and_tail(&self) -> (Option<u8>, Self) {
+        if self.0.len() == 0 {
+            return (None, ByteKey(self.0.clone()));
+        }
+
+        (Some(self.0[0]), ByteKey::from(self.0[1..].to_vec()))
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -28,7 +28,7 @@ impl Key<u8> for ByteKey {
             return ByteKey(self.0.clone());
         }
 
-         ByteKey::from(self.0[1..].to_vec())
+        ByteKey::from(self.0[1..].to_vec())
     }
 
     fn len(&self) -> usize {

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -24,7 +24,7 @@ impl From<ByteKey> for NibbleKey {
 
 impl Key<u8> for ByteKey {
     fn head_and_tail(&self) -> (Option<u8>, Self) {
-        if self.0.len() == 0 {
+        if self.0.is_empty() {
             return (None, ByteKey(self.0.clone()));
         }
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,10 +1,10 @@
 pub mod binary_key;
 pub mod byte_key;
-//pub mod nibble_key;
+pub mod nibble_key;
 
 pub use binary_key::*;
 pub use byte_key::*;
-//pub use nibble_key::*;
+pub use nibble_key::*;
 
 pub trait Key<T> {
     /// separates the "head" unit (i.e. bit, nibble or byte) from

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -6,12 +6,16 @@ pub use binary_key::*;
 pub use byte_key::*;
 pub use nibble_key::*;
 
+/// Used as an abstraction of the key type, for handling in generic
+/// tree/proof constructions.
 pub trait Key<T> {
-    /// separates the "head" unit (i.e. bit, nibble or byte) from
+    /// Separates the "head" unit (i.e. bit, nibble or byte) from
     /// the "tail", i.e. the rest of the key.
     fn head_and_tail(&self) -> (Option<T>, Self);
 
+    /// Returns the number of units (i.e. bit, nibble or byte)
     fn len(&self) -> usize;
 
+    /// Returns `true` if the key is zero unit long.
     fn is_empty(&self) -> bool;
 }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -9,9 +9,10 @@ pub use nibble_key::*;
 /// Used as an abstraction of the key type, for handling in generic
 /// tree/proof constructions.
 pub trait Key<T> {
-    /// Separates the "head" unit (i.e. bit, nibble or byte) from
-    /// the "tail", i.e. the rest of the key.
-    fn head_and_tail(&self) -> (Option<T>, Self);
+    /// Returns a copy of the current key, in which the first unit
+    /// (i.e. byte, bit, nibble) has been removed. Note that the
+    /// tail of an empty list is another empty list.
+    fn tail(&self) -> Self;
 
     /// Returns the number of units (i.e. bit, nibble or byte)
     fn len(&self) -> usize;

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,0 +1,17 @@
+pub mod binary_key;
+pub mod byte_key;
+//pub mod nibble_key;
+
+pub use binary_key::*;
+pub use byte_key::*;
+//pub use nibble_key::*;
+
+pub trait Key<T> {
+    /// separates the "head" unit (i.e. bit, nibble or byte) from
+    /// the "tail", i.e. the rest of the key.
+    fn head_and_tail(&self) -> (Option<T>, Self);
+
+    fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool;
+}

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -1,4 +1,4 @@
-use super::keys::byte_key::ByteKey;
+use super::byte_key::ByteKey;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct NibbleKey(Vec<u8>);

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -26,12 +26,12 @@ impl From<&[u8]> for NibbleKey {
 }
 
 impl Key<u8> for NibbleKey {
-    fn head_and_tail(&self) -> (Option<u8>, Self) {
+    fn tail(&self) -> Self {
         if self.0.is_empty() {
-            return (None, NibbleKey(self.0.clone()));
+            return NibbleKey(self.0.clone());
         }
 
-        (Some(self.0[0]), NibbleKey::from(self.0[1..].to_vec()))
+        NibbleKey::from(self.0[1..].to_vec())
     }
 
     fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,12 @@ pub mod keys;
 pub mod multiproof;
 pub mod node;
 pub mod tree;
-pub mod utils;
 
 pub use instruction::*;
 pub use keys::*;
 pub use multiproof::*;
 pub use node::*;
 pub use tree::{NodeType, Tree};
-pub use utils::*;
 
 impl<N: NodeType, T: Tree<N> + rlp::Decodable> ProofToTree<N, T> for Multiproof {
     fn rebuild(&self) -> Result<T, String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,14 @@ extern crate rlp;
 extern crate sha3;
 
 pub mod instruction;
+pub mod keys;
 pub mod multiproof;
 pub mod node;
 pub mod tree;
 pub mod utils;
 
 pub use instruction::*;
+pub use keys::*;
 pub use multiproof::*;
 pub use node::*;
 pub use tree::{NodeType, Tree};
@@ -447,7 +449,7 @@ mod tests {
             ("0x1111111111333333333333333333333333333333", vec![13u8; 32]),
         ];
 
-        let nibble_from_hex = |h| NibbleKey::from(utils::ByteKey(hex::decode(h).unwrap()));
+        let nibble_from_hex = |h| NibbleKey::from(keys::ByteKey(hex::decode(h).unwrap()));
 
         let mut root = Node::default();
         for i in &inputs {
@@ -485,7 +487,7 @@ mod tests {
             let mut hasher = Keccak256::new();
             hasher.input(&address_bytes);
             let address_hash = Vec::<u8>::from(&hasher.result()[..]);
-            let byte_key = utils::ByteKey(address_hash.to_vec());
+            let byte_key = keys::ByteKey(address_hash.to_vec());
 
             let val_obj = v_obj[key].as_object().unwrap();
             let balance = hex::decode(&val_obj["balance"].as_str().unwrap()[2..]).unwrap();

--- a/src/multiproof.rs
+++ b/src/multiproof.rs
@@ -56,8 +56,8 @@ impl std::fmt::Display for Multiproof {
 #[cfg(test)]
 mod tests {
     use super::super::instruction::Instruction::*;
+    use super::super::keys::NibbleKey;
     use super::super::node::Node::*;
-    use super::super::utils::*;
     use super::*;
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -2,6 +2,7 @@ extern crate sha3;
 
 use super::tree::*;
 use super::utils::*;
+use super::*;
 use sha3::{Digest, Keccak256};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -504,7 +505,6 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
-    use super::super::utils;
     use super::Node::*;
     use super::*;
 
@@ -1000,7 +1000,7 @@ mod tests {
 
         let mut root = Branch(vec![EmptySlot; 16]);
         for (ik, iv) in inputs.iter() {
-            let k = NibbleKey::from(utils::ByteKey(hex::decode(&ik[2..]).unwrap()));
+            let k = NibbleKey::from(keys::ByteKey(hex::decode(&ik[2..]).unwrap()));
             let v = hex::decode(&iv[2..]).unwrap();
             root.insert(&k, v).unwrap();
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,6 @@
 extern crate sha3;
 
 use super::tree::*;
-use super::utils::*;
 use super::*;
 use sha3::{Digest, Keccak256};
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -14,7 +14,7 @@ pub struct NodeChildIterator<'a, N: NodeType, T: Tree<N>> {
 /// also implement the `Default` trait.
 pub trait NodeType: Default {
     /// The tree's key type. Must be specified when implementing this trait.
-    type Key;
+    type Key: std::ops::Index<usize>;
     /// The tree's value type. Must be specified when implementing this trait.
     type Value;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,25 +1,7 @@
+use super::keys::byte_key::ByteKey;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct NibbleKey(Vec<u8>);
-#[derive(Debug, PartialEq, Clone)]
-pub struct ByteKey(pub Vec<u8>);
-
-impl From<Vec<u8>> for ByteKey {
-    fn from(bytes: Vec<u8>) -> Self {
-        ByteKey(bytes)
-    }
-}
-
-impl From<ByteKey> for NibbleKey {
-    fn from(address: ByteKey) -> Self {
-        let mut nibbles = Vec::new();
-        for nibble in 0..2 * address.0.len() {
-            let nibble_shift = (1 - nibble % 2) * 4;
-
-            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
-        }
-        NibbleKey(nibbles)
-    }
-}
 
 impl From<Vec<u8>> for NibbleKey {
     fn from(nibbles: Vec<u8>) -> Self {


### PR DESCRIPTION
This is preparation work for the support of binary trees.

  * It introduces a `Key` trait that will have to be implemented by all objects that can be used as keys;
  * It introduces `BinaryKey` that implements `Key` and represents a bit-wise string;
  * It rewrites `ByteKey` and `NibbleKey` as an implementation of `Key`; and
  * it moves `ByteKey`, `NibbleKey` and `BinaryKey` to their own modules.