### PR TITLE
Refactor node type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,10 +12,10 @@ pub mod utils;
 pub use instruction::*;
 pub use multiproof::*;
 pub use node::*;
-pub use tree::{KeyValueStore, Tree};
+pub use tree::{NodeType, Tree};
 pub use utils::*;
 
-impl<S: KeyValueStore, T: Tree<S> + rlp::Decodable> ProofToTree<S, T> for Multiproof {
+impl<N: NodeType, T: Tree<N> + rlp::Decodable> ProofToTree<N, T> for Multiproof {
     fn rebuild(&self) -> Result<T, String> {
         use Instruction::*;
 

--- a/src/multiproof.rs
+++ b/src/multiproof.rs
@@ -1,7 +1,7 @@
 use super::instruction::*;
-use super::tree::{KeyValueStore, Tree};
+use super::tree::{NodeType, Tree};
 
-pub trait ProofToTree<S: KeyValueStore, T: Tree<S>> {
+pub trait ProofToTree<N: NodeType, T: Tree<N>> {
     /// Rebuilds a tree of type `T` based on the proof's components.
     fn rebuild(&self) -> Result<T, String>;
 }

--- a/src/node.rs
+++ b/src/node.rs
@@ -13,7 +13,7 @@ pub enum Node {
     EmptySlot,
 }
 
-impl KeyValueStore for Node {
+impl NodeType for Node {
     type Key = NibbleKey;
     type Value = Vec<u8>;
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,13 +1,18 @@
-pub struct NodeChildIterator<'a, S: KeyValueStore, T: Tree<S>> {
+pub struct NodeChildIterator<'a, N: NodeType, T: Tree<N>> {
     /// The iterator's current child index.
     pub index: usize,
     /// The node's current key, if available.
-    pub key: Option<&'a S::Key>,
+    pub key: Option<&'a N::Key>,
     /// The node whose children are being iterated on.
     pub node: &'a T,
 }
 
-pub trait KeyValueStore {
+/// Represents the type of keys and values stored into the tree.
+///
+/// To implement tre trait, one has to specify the types of `Key`
+/// and `Value`. A further requirement is that implementors must
+/// also implement the `Default` trait.
+pub trait NodeType: Default {
     /// The tree's key type. Must be specified when implementing this trait.
     type Key;
     /// The tree's value type. Must be specified when implementing this trait.
@@ -15,7 +20,7 @@ pub trait KeyValueStore {
 }
 
 /// A trait representing the an underlying tree structure.
-pub trait Tree<S: KeyValueStore>: Sized {
+pub trait Tree<N: NodeType>: Sized {
     /// Specifies if the current tree is a simple leaf.
     fn is_leaf(&self) -> bool;
     /// Specifies if the current tree is empty.
@@ -27,11 +32,11 @@ pub trait Tree<S: KeyValueStore>: Sized {
     /// Set child node #i of the current node.
     fn set_ith_child(&mut self, index: usize, child: &Self);
     /// Returns an iterator to the node's children. Some of these nodes can be empty.
-    fn children(&self) -> NodeChildIterator<S, Self>;
+    fn children(&self) -> NodeChildIterator<N, Self>;
     /// Insert a `(key,value)` pair into a (sub-)tree represented by `root`.
-    fn insert(&mut self, key: &S::Key, value: S::Value) -> Result</* TODO &mut self */ (), String>;
+    fn insert(&mut self, key: &N::Key, value: N::Value) -> Result</* TODO &mut self */ (), String>;
 
-    fn value(&self) -> Option<&S::Value>;
+    fn value(&self) -> Option<&N::Value>;
     fn value_length(&self) -> Option<usize>;
 
     fn from_hash(h: Vec<u8>) -> Self;
@@ -41,7 +46,7 @@ pub trait Tree<S: KeyValueStore>: Sized {
     fn new_leaf(key: Vec<u8>, value: Vec<u8>) -> Self;
 }
 
-impl<'a, S: KeyValueStore, T: Tree<S>> std::iter::Iterator for NodeChildIterator<'a, S, T> {
+impl<'a, N: NodeType, T: Tree<N>> std::iter::Iterator for NodeChildIterator<'a, N, T> {
     type Item = &'a T;
 
     #[inline]


### PR DESCRIPTION
This is a minor PR in preparation for the support of binary trees. `KeyValueStore` is replaced by `NodeType`, which is intended to evolve as a description of how a node behaves in a given tree.