### PR TITLE
Key trait + move code for each key to its own file

### DIFF
--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -1,0 +1,49 @@
+use super::super::NibbleKey;
+use super::{Key, KeyIterator};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ByteKey(pub Vec<u8>);
+
+impl From<Vec<u8>> for ByteKey {
+    fn from(bytes: Vec<u8>) -> Self {
+        ByteKey(bytes)
+    }
+}
+
+impl From<ByteKey> for NibbleKey {
+    fn from(address: ByteKey) -> Self {
+        let mut nibbles = Vec::new();
+        for nibble in 0..2 * address.0.len() {
+            let nibble_shift = (1 - nibble % 2) * 4;
+
+            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
+        }
+        NibbleKey::from(nibbles)
+    }
+}
+
+impl Key<u8> for ByteKey {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn component_iter(&self) -> KeyIterator<u8, Self> {
+        KeyIterator::<u8, Self> {
+            item_num: 0,
+            container: &self,
+            last_element: 0,
+        }
+    }
+}
+
+impl std::ops::Index<usize> for ByteKey {
+    type Output = u8;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.0[i]
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,0 +1,51 @@
+pub mod byte_key;
+pub mod nibble_key;
+
+pub use byte_key::*;
+pub use nibble_key::*;
+
+/// An iterator that will walk the elements of the key. `U` is the unit
+/// type of a key element (e.g. byte, bit, nibble) and `K` is the key type.
+pub struct KeyIterator<'a, U, K: Key<U> + std::ops::Index<usize, Output = U>> {
+    /// Index of the element that the iterator is currently pointing at.
+    item_num: usize,
+
+    /// A reference to the object being iterated.
+    container: &'a K,
+
+    last_element: U,
+}
+
+/// Used as an abstraction of the key type, for handling in generic
+/// tree/proof constructions.
+pub trait Key<T: std::marker::Sized> {
+    /// Returns the number of units (i.e. bit, nibble or byte)
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the key is zero unit long.
+    fn is_empty(&self) -> bool;
+
+    /// Returns an iterator over the key components (bit, byte, etc...)
+    fn component_iter(&self) -> KeyIterator<T, Self>
+    where
+        Self: std::marker::Sized + std::ops::Index<usize, Output = T>;
+}
+
+impl<'a, U, K> Iterator for KeyIterator<'a, U, K>
+where
+    U: std::marker::Sized + Copy,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    type Item = U;
+
+    fn next(&mut self) -> Option<U> {
+        if self.item_num < self.container.len() {
+            let element: U = self.container[self.item_num];
+            self.item_num += 1;
+            self.last_element = element;
+            Some(element)
+        } else {
+            None
+        }
+    }
+}

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -1,25 +1,12 @@
+use super::byte_key::ByteKey;
+use super::{Key, KeyIterator};
+
+/// Represents a key whose unit is nibbles, i.e. 4-byte long values.
+///
+/// Internally, nibbles are stored in a byte array, with each byte
+/// having its most significant nibble set to 0.
 #[derive(Debug, PartialEq, Clone)]
 pub struct NibbleKey(Vec<u8>);
-#[derive(Debug, PartialEq, Clone)]
-pub struct ByteKey(pub Vec<u8>);
-
-impl From<Vec<u8>> for ByteKey {
-    fn from(bytes: Vec<u8>) -> Self {
-        ByteKey(bytes)
-    }
-}
-
-impl From<ByteKey> for NibbleKey {
-    fn from(address: ByteKey) -> Self {
-        let mut nibbles = Vec::new();
-        for nibble in 0..2 * address.0.len() {
-            let nibble_shift = (1 - nibble % 2) * 4;
-
-            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
-        }
-        NibbleKey(nibbles)
-    }
-}
 
 impl From<Vec<u8>> for NibbleKey {
     fn from(nibbles: Vec<u8>) -> Self {
@@ -38,8 +25,26 @@ impl From<&[u8]> for NibbleKey {
     }
 }
 
+impl Key<u8> for NibbleKey {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn component_iter(&self) -> KeyIterator<u8, Self> {
+        KeyIterator::<u8, Self> {
+            item_num: 0,
+            container: &self,
+            last_element: 0,
+        }
+    }
+}
+
 impl NibbleKey {
-    // Find the length of the common prefix of two keys
+    /// Finds the length of the common prefix of two keys.
     pub fn factor_length(&self, other: &Self) -> usize {
         let (ref longuest, ref shortest) = if self.0.len() > other.0.len() {
             (&self.0, &other.0)
@@ -61,16 +66,8 @@ impl NibbleKey {
         firstdiffindex
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    // This method encodes a nibble key to its hex prefix. The output
-    // is byte-encoded, so as to be stored immediately.
+    /// Encodes a nibble key to its hex prefix. The output
+    /// is byte-encoded, so as to be stored immediately.
     pub fn with_hex_prefix(&self, is_terminator: bool) -> Vec<u8> {
         let ft = if is_terminator { 2 } else { 0 };
         let mut output = vec![0u8; self.0.len() / 2 + 1];
@@ -91,6 +88,8 @@ impl NibbleKey {
         output
     }
 
+    /// Rebuilds the hex prefix from a `&[u8]` slice assumed to
+    /// be hex prefix-encoded.
     pub fn remove_hex_prefix(payload: &[u8]) -> NibbleKey {
         if payload.is_empty() {
             return NibbleKey::from(payload);
@@ -174,18 +173,6 @@ impl From<NibbleKey> for ByteKey {
             result.push(saved);
         }
         ByteKey(result)
-    }
-}
-
-pub fn remove_indicator_prefix(key_nibbles: Vec<u8>) -> Vec<u8> {
-    // only leaf nodes and extension nodes have an indicator prefix
-    if key_nibbles[0] == 1 || key_nibbles[0] == 3 {
-        // if indicator byte is 1, it's an odd-length non-terminal node (extension node)
-        // if 3, it's an odd-length terminal node (leaf node)
-        key_nibbles[1..].to_vec()
-    } else {
-        // if even, should prefix should be either 0 or 2
-        key_nibbles[2..].to_vec()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,16 @@ extern crate rlp;
 extern crate sha3;
 
 pub mod instruction;
+pub mod keys;
 pub mod multiproof;
 pub mod node;
 pub mod tree;
-pub mod utils;
 
 pub use instruction::*;
+pub use keys::*;
 pub use multiproof::*;
 pub use node::*;
 pub use tree::{NodeType, Tree};
-pub use utils::*;
 
 impl<N: NodeType, T: Tree<N> + rlp::Decodable> ProofToTree<N, T> for Multiproof {
     fn rebuild(&self) -> Result<T, String> {
@@ -447,7 +447,7 @@ mod tests {
             ("0x1111111111333333333333333333333333333333", vec![13u8; 32]),
         ];
 
-        let nibble_from_hex = |h| NibbleKey::from(utils::ByteKey(hex::decode(h).unwrap()));
+        let nibble_from_hex = |h| NibbleKey::from(keys::ByteKey(hex::decode(h).unwrap()));
 
         let mut root = Node::default();
         for i in &inputs {
@@ -485,7 +485,7 @@ mod tests {
             let mut hasher = Keccak256::new();
             hasher.input(&address_bytes);
             let address_hash = Vec::<u8>::from(&hasher.result()[..]);
-            let byte_key = utils::ByteKey(address_hash.to_vec());
+            let byte_key = keys::ByteKey(address_hash.to_vec());
 
             let val_obj = v_obj[key].as_object().unwrap();
             let balance = hex::decode(&val_obj["balance"].as_str().unwrap()[2..]).unwrap();

--- a/src/multiproof.rs
+++ b/src/multiproof.rs
@@ -56,8 +56,8 @@ impl std::fmt::Display for Multiproof {
 #[cfg(test)]
 mod tests {
     use super::super::instruction::Instruction::*;
+    use super::super::keys::NibbleKey;
     use super::super::node::Node::*;
-    use super::super::utils::*;
     use super::*;
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 extern crate sha3;
 
 use super::tree::*;
-use super::utils::*;
+use super::*;
 use sha3::{Digest, Keccak256};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -505,7 +505,6 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
-    use super::super::utils;
     use super::Node::*;
     use super::*;
 
@@ -1001,7 +1000,7 @@ mod tests {
 
         let mut root = Branch(vec![EmptySlot; 16]);
         for (ik, iv) in inputs.iter() {
-            let k = NibbleKey::from(utils::ByteKey(hex::decode(&ik[2..]).unwrap()));
+            let k = NibbleKey::from(keys::ByteKey(hex::decode(&ik[2..]).unwrap()));
             let v = hex::decode(&iv[2..]).unwrap();
             root.insert(&k, v).unwrap();
         }


### PR DESCRIPTION
This is a new take on #49 that attempts to replace the indexing with an iterator. The binary key is currently not added, to simplify the PR.