### PR TITLE
[DONTMERGE] Use iterator for keys

### DIFF
--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -31,11 +31,11 @@ impl Key<u8> for ByteKey {
         self.0.is_empty()
     }
 
-    fn component_iter(&self) -> KeyIterator<u8, Self> {
+    fn iter(&self) -> KeyIterator<u8, Self> {
         KeyIterator::<u8, Self> {
             item_num: 0,
             container: &self,
-            last_element: 0,
+            element: 0,
         }
     }
 }

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -1,0 +1,49 @@
+use super::super::NibbleKey;
+use super::{Key, KeyIterator};
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct ByteKey(pub Vec<u8>);
+
+impl From<Vec<u8>> for ByteKey {
+    fn from(bytes: Vec<u8>) -> Self {
+        ByteKey(bytes)
+    }
+}
+
+impl From<ByteKey> for NibbleKey {
+    fn from(address: ByteKey) -> Self {
+        let mut nibbles = Vec::new();
+        for nibble in 0..2 * address.0.len() {
+            let nibble_shift = (1 - nibble % 2) * 4;
+
+            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
+        }
+        NibbleKey::from(nibbles)
+    }
+}
+
+impl Key<u8> for ByteKey {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn component_iter(&self) -> KeyIterator<u8, Self> {
+        KeyIterator::<u8, Self> {
+            item_num: 0,
+            container: &self,
+            last_element: 0,
+        }
+    }
+}
+
+impl std::ops::Index<usize> for ByteKey {
+    type Output = u8;
+
+    fn index(&self, i: usize) -> &Self::Output {
+        &self.0[i]
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -1,0 +1,51 @@
+pub mod byte_key;
+pub mod nibble_key;
+
+pub use byte_key::*;
+pub use nibble_key::*;
+
+/// An iterator that will walk the elements of the key. `U` is the unit
+/// type of a key element (e.g. byte, bit, nibble) and `K` is the key type.
+pub struct KeyIterator<'a, U, K: Key<U> + std::ops::Index<usize, Output = U>> {
+    /// Index of the element that the iterator is currently pointing at.
+    item_num: usize,
+
+    /// A reference to the object being iterated.
+    container: &'a K,
+
+    last_element: U,
+}
+
+/// Used as an abstraction of the key type, for handling in generic
+/// tree/proof constructions.
+pub trait Key<T: std::marker::Sized> {
+    /// Returns the number of units (i.e. bit, nibble or byte)
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the key is zero unit long.
+    fn is_empty(&self) -> bool;
+
+    /// Returns an iterator over the key components (bit, byte, etc...)
+    fn component_iter(&self) -> KeyIterator<T, Self>
+    where
+        Self: std::marker::Sized + std::ops::Index<usize, Output = T>;
+}
+
+impl<'a, U, K> Iterator for KeyIterator<'a, U, K>
+where
+    U: std::marker::Sized + Copy,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    type Item = U;
+
+    fn next(&mut self) -> Option<U> {
+        if self.item_num < self.container.len() {
+            let element: U = self.container[self.item_num];
+            self.item_num += 1;
+            self.last_element = element;
+            Some(element)
+        } else {
+            None
+        }
+    }
+}

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -6,34 +6,38 @@ pub use nibble_key::*;
 
 /// An iterator that will walk the elements of the key. `U` is the unit
 /// type of a key element (e.g. byte, bit, nibble) and `K` is the key type.
-pub struct KeyIterator<'a, U, K: Key<U> + std::ops::Index<usize, Output = U>> {
+pub struct KeyIterator<'a, U, K>
+where
+    U: Copy + PartialEq + std::fmt::Debug + Default,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
     /// Index of the element that the iterator is currently pointing at.
     item_num: usize,
 
     /// A reference to the object being iterated.
     container: &'a K,
 
-    last_element: U,
+    element: U,
 }
 
-/// Used as an abstraction of the key type, for handling in generic
-/// tree/proof constructions.
-pub trait Key<T: std::marker::Sized> {
-    /// Returns the number of units (i.e. bit, nibble or byte)
-    fn len(&self) -> usize;
-
-    /// Returns `true` if the key is zero unit long.
-    fn is_empty(&self) -> bool;
-
-    /// Returns an iterator over the key components (bit, byte, etc...)
-    fn component_iter(&self) -> KeyIterator<T, Self>
-    where
-        Self: std::marker::Sized + std::ops::Index<usize, Output = T>;
+impl<'a, U, K> std::fmt::Debug for KeyIterator<'a, U, K>
+where
+    U: std::marker::Sized + Copy + PartialEq + std::fmt::Debug + Default,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "iterator at element {}/{}",
+            self.item_num,
+            self.container.len()
+        )
+    }
 }
 
 impl<'a, U, K> Iterator for KeyIterator<'a, U, K>
 where
-    U: std::marker::Sized + Copy,
+    U: std::marker::Sized + Copy + PartialEq + std::fmt::Debug + Default,
     K: Key<U> + std::ops::Index<usize, Output = U>,
 {
     type Item = U;
@@ -42,10 +46,75 @@ where
         if self.item_num < self.container.len() {
             let element: U = self.container[self.item_num];
             self.item_num += 1;
-            self.last_element = element;
+            self.element = element;
             Some(element)
         } else {
             None
         }
     }
+}
+
+impl<'a, U, K> KeyIterator<'a, U, K>
+where
+    U: std::marker::Sized + Copy + PartialEq + std::fmt::Debug + Default,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    fn rewind(&mut self) {
+        assert!(self.item_num > 0);
+        self.item_num -= 1;
+    }
+
+    /// Compares the two iterators and leave them at their first differing
+    /// element.
+    pub fn chop_common(&mut self, other: &mut Self) -> usize {
+        loop {
+            let (rewind, brk) = match (self.next(), other.next()) {
+                // Both iterators reached the end, keys are
+                // identical.
+                (None, None) => (false, true),
+                // One of the iterators has reached the end,
+                // advance both and return.
+                (_, None) | (None, _) => (true, true),
+                // Both iterators are still pointing at a
+                // value, check if these values are the same.
+                // If they are, loop, otherwise quit.
+                (Some(x), Some(y)) => (x != y, x != y),
+            };
+
+            if rewind {
+                self.rewind();
+                other.rewind();
+            }
+
+            if brk {
+                break;
+            }
+        }
+        self.course()
+    }
+
+    fn course(&self) -> usize {
+        self.item_num
+    }
+
+    pub fn is_end(&self) -> bool {
+        self.item_num >= self.container.len()
+    }
+}
+
+/// Used as an abstraction of the key type, for handling in generic
+/// tree/proof constructions.
+pub trait Key<T>
+where
+{
+    /// Returns the number of units (i.e. bit, nibble or byte)
+    fn len(&self) -> usize;
+
+    /// Returns `true` if the key is zero unit long.
+    fn is_empty(&self) -> bool;
+
+    /// Returns an iterator over the key components (bit, byte, etc...)
+    fn iter(&self) -> KeyIterator<T, Self>
+    where
+        Self: std::marker::Sized + std::ops::Index<usize, Output = T>;
 }

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -135,6 +135,7 @@ impl std::ops::Index<std::ops::RangeFrom<usize>> for NibbleKey {
 impl std::ops::Index<std::ops::RangeTo<usize>> for NibbleKey {
     type Output = [u8];
 
+    // Problem here
     #[inline]
     fn index(&self, r: std::ops::RangeTo<usize>) -> &[u8] {
         &self.0[r]

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -1,25 +1,12 @@
+use super::byte_key::ByteKey;
+use super::{Key, KeyIterator};
+
+/// Represents a key whose unit is nibbles, i.e. 4-byte long values.
+///
+/// Internally, nibbles are stored in a byte array, with each byte
+/// having its most significant nibble set to 0.
 #[derive(Debug, PartialEq, Clone)]
 pub struct NibbleKey(Vec<u8>);
-#[derive(Debug, PartialEq, Clone)]
-pub struct ByteKey(pub Vec<u8>);
-
-impl From<Vec<u8>> for ByteKey {
-    fn from(bytes: Vec<u8>) -> Self {
-        ByteKey(bytes)
-    }
-}
-
-impl From<ByteKey> for NibbleKey {
-    fn from(address: ByteKey) -> Self {
-        let mut nibbles = Vec::new();
-        for nibble in 0..2 * address.0.len() {
-            let nibble_shift = (1 - nibble % 2) * 4;
-
-            nibbles.push((address.0[nibble / 2] >> nibble_shift) & 0xF);
-        }
-        NibbleKey(nibbles)
-    }
-}
 
 impl From<Vec<u8>> for NibbleKey {
     fn from(nibbles: Vec<u8>) -> Self {
@@ -38,8 +25,26 @@ impl From<&[u8]> for NibbleKey {
     }
 }
 
+impl Key<u8> for NibbleKey {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn component_iter(&self) -> KeyIterator<u8, Self> {
+        KeyIterator::<u8, Self> {
+            item_num: 0,
+            container: &self,
+            last_element: 0,
+        }
+    }
+}
+
 impl NibbleKey {
-    // Find the length of the common prefix of two keys
+    /// Finds the length of the common prefix of two keys.
     pub fn factor_length(&self, other: &Self) -> usize {
         let (ref longuest, ref shortest) = if self.0.len() > other.0.len() {
             (&self.0, &other.0)
@@ -61,16 +66,8 @@ impl NibbleKey {
         firstdiffindex
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    // This method encodes a nibble key to its hex prefix. The output
-    // is byte-encoded, so as to be stored immediately.
+    /// Encodes a nibble key to its hex prefix. The output
+    /// is byte-encoded, so as to be stored immediately.
     pub fn with_hex_prefix(&self, is_terminator: bool) -> Vec<u8> {
         let ft = if is_terminator { 2 } else { 0 };
         let mut output = vec![0u8; self.0.len() / 2 + 1];
@@ -91,6 +88,8 @@ impl NibbleKey {
         output
     }
 
+    /// Rebuilds the hex prefix from a `&[u8]` slice assumed to
+    /// be hex prefix-encoded.
     pub fn remove_hex_prefix(payload: &[u8]) -> NibbleKey {
         if payload.is_empty() {
             return NibbleKey::from(payload);
@@ -174,18 +173,6 @@ impl From<NibbleKey> for ByteKey {
             result.push(saved);
         }
         ByteKey(result)
-    }
-}
-
-pub fn remove_indicator_prefix(key_nibbles: Vec<u8>) -> Vec<u8> {
-    // only leaf nodes and extension nodes have an indicator prefix
-    if key_nibbles[0] == 1 || key_nibbles[0] == 3 {
-        // if indicator byte is 1, it's an odd-length non-terminal node (extension node)
-        // if 3, it's an odd-length terminal node (leaf node)
-        key_nibbles[1..].to_vec()
-    } else {
-        // if even, should prefix should be either 0 or 2
-        key_nibbles[2..].to_vec()
     }
 }
 

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -8,6 +8,12 @@ use super::{Key, KeyIterator};
 #[derive(Debug, PartialEq, Clone)]
 pub struct NibbleKey(Vec<u8>);
 
+impl<'a> From<KeyIterator<'a, u8, NibbleKey>> for NibbleKey {
+    fn from(it: KeyIterator<'a, u8, NibbleKey>) -> Self {
+        NibbleKey(it.container.0[it.item_num..].to_vec())
+    }
+}
+
 impl From<Vec<u8>> for NibbleKey {
     fn from(nibbles: Vec<u8>) -> Self {
         for nibble in nibbles.iter() {
@@ -34,38 +40,16 @@ impl Key<u8> for NibbleKey {
         self.0.is_empty()
     }
 
-    fn component_iter(&self) -> KeyIterator<u8, Self> {
+    fn iter(&self) -> KeyIterator<u8, Self> {
         KeyIterator::<u8, Self> {
             item_num: 0,
             container: &self,
-            last_element: 0,
+            element: 0,
         }
     }
 }
 
 impl NibbleKey {
-    /// Finds the length of the common prefix of two keys.
-    pub fn factor_length(&self, other: &Self) -> usize {
-        let (ref longuest, ref shortest) = if self.0.len() > other.0.len() {
-            (&self.0, &other.0)
-        } else {
-            (&other.0, &self.0)
-        };
-
-        let mut firstdiffindex = shortest.len();
-        for (i, &n) in shortest.iter().enumerate() {
-            if n != longuest[i] {
-                firstdiffindex = i as usize;
-                break;
-            }
-        }
-
-        assert!(firstdiffindex <= other.0.len());
-        assert!(firstdiffindex <= self.0.len());
-
-        firstdiffindex
-    }
-
     /// Encodes a nibble key to its hex prefix. The output
     /// is byte-encoded, so as to be stored immediately.
     pub fn with_hex_prefix(&self, is_terminator: bool) -> Vec<u8> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,13 +213,13 @@ pub fn make_multiproof(root: &Node, keys: Vec<NibbleKey>) -> Result<Multiproof, 
             // prefix removed.
             let mut truncated = vec![];
             for k in keys.iter() {
-                let factor_length = extkey.factor_length(k);
+                let common_length = extkey.common_length(k);
                 // If a key has a prefix that differs from that of the extension,
                 // then it is missing in this tree and is not added to the list
                 // of shortened keys to be recursively passed down. This special
                 // case is handled after the loop.
-                if factor_length == extkey.len() {
-                    truncated.push(NibbleKey::from(&k[factor_length..]));
+                if common_length == extkey.len() {
+                    truncated.push(NibbleKey::from(&k[common_length..]));
                 }
             }
             // If truncated.len() > 0, there is at least one requested key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,16 @@ extern crate rlp;
 extern crate sha3;
 
 pub mod instruction;
+pub mod keys;
 pub mod multiproof;
 pub mod node;
 pub mod tree;
-pub mod utils;
 
 pub use instruction::*;
+pub use keys::*;
 pub use multiproof::*;
 pub use node::*;
 pub use tree::{NodeType, Tree};
-pub use utils::*;
 
 impl<N: NodeType, T: Tree<N> + rlp::Decodable> ProofToTree<N, T> for Multiproof {
     fn rebuild(&self) -> Result<T, String> {
@@ -447,7 +447,7 @@ mod tests {
             ("0x1111111111333333333333333333333333333333", vec![13u8; 32]),
         ];
 
-        let nibble_from_hex = |h| NibbleKey::from(utils::ByteKey(hex::decode(h).unwrap()));
+        let nibble_from_hex = |h| NibbleKey::from(keys::ByteKey(hex::decode(h).unwrap()));
 
         let mut root = Node::default();
         for i in &inputs {
@@ -485,7 +485,7 @@ mod tests {
             let mut hasher = Keccak256::new();
             hasher.input(&address_bytes);
             let address_hash = Vec::<u8>::from(&hasher.result()[..]);
-            let byte_key = utils::ByteKey(address_hash.to_vec());
+            let byte_key = keys::ByteKey(address_hash.to_vec());
 
             let val_obj = v_obj[key].as_object().unwrap();
             let balance = hex::decode(&val_obj["balance"].as_str().unwrap()[2..]).unwrap();

--- a/src/multiproof.rs
+++ b/src/multiproof.rs
@@ -56,8 +56,8 @@ impl std::fmt::Display for Multiproof {
 #[cfg(test)]
 mod tests {
     use super::super::instruction::Instruction::*;
+    use super::super::keys::NibbleKey;
     use super::super::node::Node::*;
-    use super::super::utils::*;
     use super::*;
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,7 +1,7 @@
 extern crate sha3;
 
 use super::tree::*;
-use super::utils::*;
+use super::*;
 use sha3::{Digest, Keccak256};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -505,7 +505,6 @@ impl Node {
 
 #[cfg(test)]
 mod tests {
-    use super::super::utils;
     use super::Node::*;
     use super::*;
 
@@ -1001,7 +1000,7 @@ mod tests {
 
         let mut root = Branch(vec![EmptySlot; 16]);
         for (ik, iv) in inputs.iter() {
-            let k = NibbleKey::from(utils::ByteKey(hex::decode(&ik[2..]).unwrap()));
+            let k = NibbleKey::from(keys::ByteKey(hex::decode(&ik[2..]).unwrap()));
             let v = hex::decode(&iv[2..]).unwrap();
             root.insert(&k, v).unwrap();
         }


### PR DESCRIPTION
This PR needs to be rebased, only applies iterators to `Extension` nodes and is only here for discussing the following points:

 - [ ] `Index`'s `index -> &[u8]` makes it impossible to make bit keys and nibble keys as simple `Vec<u8>`: the data needs to be expanded in another `Vec<u8>` in which each byte represents one bit/nibble
 - [ ] the need for `rewind`
 - [ ] the general API and code of `chop_common`