### PR TITLE
[WIP] use iterators to progress over binary keys

### DIFF
--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -91,19 +91,17 @@ impl Tree<BinaryTree> for BinaryTree {
                     (Some(k), Some(l)) if k == l => {
                         let mut child = BinaryTree::Leaf(BinaryKey::from(lit), leafvalue.to_vec());
                         child.insert(&BinaryKey::from(kit), value)?;
-                        let (left, right) = match k {
-                            false => (child, BinaryTree::EmptyChild),
-                            true => (BinaryTree::EmptyChild, child),
+                        let (left, right) = if k {
+                            (BinaryTree::EmptyChild, child)
+                        } else {
+                            (child, BinaryTree::EmptyChild)
                         };
                         *self = BinaryTree::Branch(Box::new(left), Box::new(right));
                     }
                     (Some(k), Some(_)) => {
                         let orig = BinaryTree::Leaf(BinaryKey::from(lit), leafvalue.to_vec());
                         let new = BinaryTree::Leaf(BinaryKey::from(kit), value);
-                        let (left, right) = match k {
-                            false => (new, orig),
-                            true => (orig, new),
-                        };
+                        let (left, right) = if k { (orig, new) } else { (new, orig) };
                         *self = BinaryTree::Branch(Box::new(left), Box::new(right));
                     }
                     // Both reached the end, update (TODO)

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -92,8 +92,8 @@ impl Tree<BinaryTree> for BinaryTree {
                         let mut child = BinaryTree::Leaf(BinaryKey::from(lit), leafvalue.to_vec());
                         child.insert(&BinaryKey::from(kit), value)?;
                         let (left, right) = match k {
-                            true => (child, BinaryTree::EmptyChild),
-                            false => (BinaryTree::EmptyChild, child),
+                            false => (child, BinaryTree::EmptyChild),
+                            true => (BinaryTree::EmptyChild, child),
                         };
                         *self = BinaryTree::Branch(Box::new(left), Box::new(right));
                     }
@@ -114,9 +114,9 @@ impl Tree<BinaryTree> for BinaryTree {
             }
             BinaryTree::Branch(box left, box right) => {
                 if key[0] {
-                    left.insert(&key.tail(), value)
-                } else {
                     right.insert(&key.tail(), value)
+                } else {
+                    left.insert(&key.tail(), value)
                 }
             }
             BinaryTree::EmptyChild => {
@@ -212,7 +212,7 @@ mod tests {
         assert_eq!(
             root,
             Branch(
-                Box::new(Leaf(BinaryKey::new(vec![5u8; 32], 6, 0), vec![10; 32])),
+                Box::new(Leaf(BinaryKey::new(vec![5u8; 32], 1, 256), vec![10; 32])),
                 Box::new(EmptyChild)
             )
         );
@@ -231,8 +231,8 @@ mod tests {
                 Box::new(Branch(
                     Box::new(EmptyChild),
                     Box::new(Branch(
-                        Box::new(Leaf(BinaryKey::new(vec![0x55u8; 32], 4, 0), vec![10; 32])),
-                        Box::new(Leaf(BinaryKey::new(vec![0x66u8; 32], 4, 0), vec![10; 32])),
+                        Box::new(Leaf(BinaryKey::new(vec![0x55u8; 32], 3, 256), vec![10; 32])),
+                        Box::new(Leaf(BinaryKey::new(vec![0x66u8; 32], 3, 256), vec![10; 32])),
                     )),
                 )),
                 Box::new(EmptyChild)

--- a/src/binary_tree.rs
+++ b/src/binary_tree.rs
@@ -81,42 +81,39 @@ impl Tree<BinaryTree> for BinaryTree {
     }
 
     fn insert(&mut self, key: &BinaryKey, value: Vec<u8>) -> Result<(), String> {
+        let mut kit = key.iter();
         match self {
             BinaryTree::Leaf(ref leafkey, leafvalue) => {
-                // Keep inserting branches until the two keys
-                // differ.
-                if leafkey[0] == key[0] {
-                    // The usual left or right question
-                    if key[0] == 0 {
-                        let mut left = BinaryTree::Leaf(leafkey.tail(), leafvalue.to_vec());
-                        left.insert(&key.tail(), value)?;
-                        *self =
-                            BinaryTree::Branch(Box::new(left), Box::new(BinaryTree::EmptyChild));
-                    } else {
-                        let mut right = BinaryTree::Leaf(leafkey.tail(), leafvalue.to_vec());
-                        right.insert(&key.tail(), value)?;
-                        *self =
-                            BinaryTree::Branch(Box::new(BinaryTree::EmptyChild), Box::new(right));
+                let mut lit = leafkey.iter();
+                match (kit.next(), lit.next()) {
+                    // Keep inserting branches until the two keys
+                    // differ.
+                    (Some(k), Some(l)) if k == l => {
+                        let mut child = BinaryTree::Leaf(BinaryKey::from(lit), leafvalue.to_vec());
+                        child.insert(&BinaryKey::from(kit), value)?;
+                        let (left, right) = match k {
+                            true => (child, BinaryTree::EmptyChild),
+                            false => (BinaryTree::EmptyChild, child),
+                        };
+                        *self = BinaryTree::Branch(Box::new(left), Box::new(right));
                     }
-                } else {
-                    // The algorithm has reached the point where both keys
-                    // differ, so create the final branch
-                    *self = if key[0] == 0 {
-                        BinaryTree::Branch(
-                            Box::new(BinaryTree::Leaf(key.tail(), value)),
-                            Box::new(BinaryTree::Leaf(leafkey.tail(), leafvalue.to_vec())),
-                        )
-                    } else {
-                        BinaryTree::Branch(
-                            Box::new(BinaryTree::Leaf(leafkey.tail(), leafvalue.to_vec())),
-                            Box::new(BinaryTree::Leaf(key.tail(), value)),
-                        )
-                    };
+                    (Some(k), Some(_)) => {
+                        let orig = BinaryTree::Leaf(BinaryKey::from(lit), leafvalue.to_vec());
+                        let new = BinaryTree::Leaf(BinaryKey::from(kit), value);
+                        let (left, right) = match k {
+                            false => (new, orig),
+                            true => (orig, new),
+                        };
+                        *self = BinaryTree::Branch(Box::new(left), Box::new(right));
+                    }
+                    // Both reached the end, update (TODO)
+                    (None, None) => panic!("No update currently supported"),
+                    _ => panic!("Key length mismatch in insert"),
                 }
                 Ok(())
             }
             BinaryTree::Branch(box left, box right) => {
-                if key[0] == 0 {
+                if key[0] {
                     left.insert(&key.tail(), value)
                 } else {
                     right.insert(&key.tail(), value)
@@ -135,7 +132,7 @@ impl Tree<BinaryTree> for BinaryTree {
             BinaryTree::Leaf(ref k, _) => k == key,
             BinaryTree::Hash(_) => false,
             BinaryTree::Branch(box left, box right) => {
-                if key[0] == 0 {
+                if key[0] {
                     left.has_key(&key.tail())
                 } else {
                     right.has_key(&key.tail())

--- a/src/keys/binary_key.rs
+++ b/src/keys/binary_key.rs
@@ -35,10 +35,6 @@ impl BinaryKey {
     pub fn new(data: Vec<u8>, start: usize, end: usize) -> Self {
         BinaryKey(data, start, end)
     }
-
-    pub fn tail(&self) -> Self {
-        BinaryKey(self.0[..].to_vec(), self.1 + 1, self.2)
-    }
 }
 
 impl From<Vec<u8>> for BinaryKey {
@@ -107,79 +103,35 @@ mod tests {
 
     #[test]
     fn test_iterate_over_one_byte() {
-        let mut key = BinaryKey::from(vec![0xFFu8]);
+        let key = BinaryKey::from(vec![0xFFu8]);
 
         assert_eq!(key.len(), 8);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 8);
-        }
-        assert_eq!(count, 8);
+        assert_eq!(key.iter().count(), 8);
     }
 
     #[test]
     fn test_iterate_over_two_bytes() {
-        let mut key = BinaryKey::from(vec![0xFFu8, 0xFFu8]);
+        let key = BinaryKey::from(vec![0xFFu8, 0xFFu8]);
 
         assert_eq!(key.len(), 16);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 16);
-        }
-        assert_eq!(count, 16);
+        assert_eq!(key.iter().count(), 16);
     }
 
     #[test]
     fn test_iterate_over_zero_bytes() {
-        let mut key = BinaryKey::from(vec![]);
+        let key = BinaryKey::from(vec![]);
 
         assert_eq!(key.len(), 0);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            assert_eq!(key.len(), 0);
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 2);
-        }
-        assert_eq!(count, 1);
+        assert_eq!(key.iter().count(), 0);
     }
 
     #[test]
     fn test_iterate_endianness() {
-        let mut key = BinaryKey::from(vec![0x55u8, 0x55u8]);
+        let key = BinaryKey::from(vec![0x55u8, 0x55u8]);
 
-        assert_eq!(key.len(), 16);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 16);
+        for (i, b) in key.iter().enumerate() {
+            assert_eq!(b, (key.len() - i) % 2 == 1);
         }
-        assert_eq!(count, 16);
     }
 
     #[test]
@@ -189,21 +141,10 @@ mod tests {
         // ---------+------------------
         // bit      | 01011111 11110101
         // pointers |     ^        ^
-        let mut key = BinaryKey(vec![0x5Fu8, 0xF5u8], 4, 12);
+        let key = BinaryKey(vec![0x5Fu8, 0xF5u8], 4, 12);
 
         assert_eq!(key.len(), 8);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 8);
-        }
-        assert_eq!(count, 8);
+        assert_eq!(key.iter().count(), 8);
     }
 
     #[test]
@@ -213,21 +154,10 @@ mod tests {
         // ---------+---------
         // bit      | 10000111
         // pointers |  ^  ^
-        let mut key = BinaryKey(vec![0x87u8], 3, 7);
+        let key = BinaryKey(vec![0x87u8], 3, 7);
 
         assert_eq!(key.len(), 4);
-
-        let mut count = 0u32;
-        loop {
-            let tail = key.tail();
-            key = tail;
-            count += 1;
-            if key.is_empty() {
-                break;
-            }
-            assert!(count < 4);
-        }
-        assert_eq!(count, 4);
+        assert_eq!(key.iter().count(), 4);
     }
 
     #[test]

--- a/src/keys/byte_key.rs
+++ b/src/keys/byte_key.rs
@@ -23,14 +23,6 @@ impl From<ByteKey> for NibbleKey {
 }
 
 impl Key<u8> for ByteKey {
-    fn tail(&self) -> Self {
-        if self.0.is_empty() {
-            return ByteKey(self.0.clone());
-        }
-
-        ByteKey::from(self.0[1..].to_vec())
-    }
-
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -6,17 +6,121 @@ pub use binary_key::*;
 pub use byte_key::*;
 pub use nibble_key::*;
 
+/// An iterator that will walk the elements of the key. `U` is the unit
+/// type of a key element (e.g. byte, bit, nibble) and `K` is the key type.
+pub struct KeyIterator<'a, U, K>
+where
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    /// Index of the element that the iterator is currently pointing at.
+    item_num: usize,
+
+    /// A reference to the object being iterated.
+    container: &'a K,
+
+    element: U,
+}
+
+impl<'a, U, K> std::fmt::Debug for KeyIterator<'a, U, K>
+where
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "iterator at element {}/{}",
+            self.item_num,
+            self.container.len()
+        )
+    }
+}
+
+impl<'a, U, K> Iterator for KeyIterator<'a, U, K>
+where
+    U: Copy,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    type Item = U;
+
+    fn next(&mut self) -> Option<U> {
+        if self.item_num < self.container.len() {
+            let element: U = self.container[self.item_num];
+            self.item_num += 1;
+            self.element = element;
+            Some(element)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, U, K> KeyIterator<'a, U, K>
+where
+    U: PartialEq + Copy,
+    K: Key<U> + std::ops::Index<usize, Output = U>,
+{
+    fn rewind(&mut self) {
+        assert!(self.item_num > 0);
+        self.item_num -= 1;
+    }
+
+    /// Compares the two iterators and leave them at their first differing
+    /// element.
+    pub fn chop_common(&mut self, other: &mut Self) -> usize {
+        loop {
+            let (rewind, brk) = match (self.next(), other.next()) {
+                // Both iterators reached the end, keys are
+                // identical.
+                (None, None) => (false, true),
+                // One of the iterators has reached the end,
+                // advance both and return.
+                (_, None) | (None, _) => (true, true),
+                // Both iterators are still pointing at a
+                // value, check if these values are the same.
+                // If they are, loop, otherwise quit.
+                (Some(x), Some(y)) => (x != y, x != y),
+            };
+
+            if rewind {
+                self.rewind();
+                other.rewind();
+            }
+
+            if brk {
+                break;
+            }
+        }
+        self.course()
+    }
+
+    fn course(&self) -> usize {
+        self.item_num
+    }
+
+    pub fn is_end(&self) -> bool {
+        self.item_num >= self.container.len()
+    }
+}
+
 /// Used as an abstraction of the key type, for handling in generic
 /// tree/proof constructions.
 pub trait Key<T> {
-    /// Returns a copy of the current key, in which the first unit
-    /// (i.e. byte, bit, nibble) has been removed. Note that the
-    /// tail of an empty list is another empty list.
-    fn tail(&self) -> Self;
-
     /// Returns the number of units (i.e. bit, nibble or byte)
     fn len(&self) -> usize;
 
     /// Returns `true` if the key is zero unit long.
     fn is_empty(&self) -> bool;
+
+    /// Returns an iterator over the key components (bit, byte, etc...)
+    fn iter(&self) -> KeyIterator<T, Self>
+    where
+        T: Default,
+        Self: std::marker::Sized + std::ops::Index<usize, Output = T>,
+    {
+        KeyIterator::<T, Self> {
+            item_num: 0,
+            container: &self,
+            element: T::default(),
+        }
+    }
 }

--- a/src/keys/nibble_key.rs
+++ b/src/keys/nibble_key.rs
@@ -26,14 +26,6 @@ impl From<&[u8]> for NibbleKey {
 }
 
 impl Key<u8> for NibbleKey {
-    fn tail(&self) -> Self {
-        if self.0.is_empty() {
-            return NibbleKey(self.0.clone());
-        }
-
-        NibbleKey::from(self.0[1..].to_vec())
-    }
-
     fn len(&self) -> usize {
         self.0.len()
     }


### PR DESCRIPTION
The way binary keys are being implemented is making it impossible to implement `Index<Range<usize>>`. This approach uses an iterator and currently only implements it on `BinaryTree`.

Left to do:

 - [ ] Use `IntoIterator`
 - [ ] Use `FromIterator`
 - [x] Get rid of `rewind`